### PR TITLE
Bug fix annotation order after selections and joins (Issue #51)

### DIFF
--- a/mlinspect/backends/_iter_creation.py
+++ b/mlinspect/backends/_iter_creation.py
@@ -73,16 +73,22 @@ def iter_input_annotation_output_resampled(inspection_count, input_data, input_a
     joined_df = output.merge(data_before_with_annotations, left_on="mlinspect_index",
                              right_on="mlinspect_index")
 
+    # After these operations, joined_df contains the following columns from left to right:
+    # output columns
+    # mlinspect_index
+    # input_data columns
+    # input_annotations columns
+
     column_index_output_end = len(output.columns)
-    output_df_view = joined_df.iloc[:, 0:column_index_output_end - 1]
-    output_df_view.columns = output.columns[0:-1]
+    output_df_view = joined_df.iloc[:, 0:column_index_output_end - 1]  # -1 excludes the mlinspect_index
+    output_df_view.columns = output.columns[0:-1] # -1 excludes the mlinspect_index
     output_columns, output_rows = get_df_row_iterator(output_df_view)
     duplicated_output_iterators = itertools.tee(output_rows, inspection_count)
 
-    column_index_input_end = column_index_output_end + len(input_data.columns) - 1
+    column_index_input_end = column_index_output_end + len(input_data.columns) - 1  # -1 excludes the mlinspect_index
 
     input_df_view = joined_df.iloc[:, column_index_output_end:column_index_input_end]
-    input_df_view.columns = input_data.columns[0:-1]
+    input_df_view.columns = input_data.columns[0:-1]  # -1 excludes the mlinspect_index
     input_columns, input_rows = get_df_row_iterator(input_df_view)
     duplicated_input_iterators = itertools.tee(input_rows, inspection_count)
 
@@ -118,18 +124,25 @@ def iter_input_annotation_output_join(inspection_count, x_data, x_annotations, y
 
     df_x_output_y = df_x_output_y.drop(['mlinspect_index_y', 'mlinspect_index_x'], axis=1)
 
+    # After these operations, df_x_output_y contains the following columns from left to right:
+    # output columns
+    # x_data columns
+    # x_annotations columns
+    # y_data columns
+    # y_annotations columns
+
     column_index_output_start = 0
-    column_index_output_end = len(output.columns) - 2
+    column_index_output_end = len(output.columns) - 2  # -2 accounts for the index columns
 
     column_index_x_start = column_index_output_end
-    column_index_x_end = column_index_x_start + len(x_data.columns) - 1
+    column_index_x_end = column_index_x_start + len(x_data.columns) - 1  # -1 accounts for mlinspect_index_x
     column_index_y_start = column_index_x_end + inspection_count
-    column_index_y_end = column_index_y_start + len(y_data.columns) - 1
+    column_index_y_end = column_index_y_start + len(y_data.columns) - 1  # -1 accounts for mlinspect_index_y
 
     input_x_view = df_x_output_y.iloc[:, column_index_x_start:column_index_x_end]
-    input_x_view.columns = x_data.columns[0:-1]
+    input_x_view.columns = x_data.columns[0:-1]  # -1 accounts for mlinspect_index_x
     input_y_view = df_x_output_y.iloc[:, column_index_y_start:column_index_y_end]
-    input_y_view.columns = y_data.columns[0:-1]
+    input_y_view.columns = y_data.columns[0:-1]  # -1 accounts for mlinspect_index_y
     input_x_columns, input_x_iterator = get_df_row_iterator(input_x_view)
     assert isinstance(input_x_columns, ColumnInfo)
     input_y_columns, input_y_iterator = get_df_row_iterator(input_y_view)

--- a/test/monkeypatching/test_patch_sklearn.py
+++ b/test/monkeypatching/test_patch_sklearn.py
@@ -112,9 +112,9 @@ def test_train_test_split():
 
     inspection_results_data_source = inspector_result.dag_node_to_inspection_results[expected_train]
     lineage_output = inspection_results_data_source[RowLineage(3)]
-    expected_lineage_df = DataFrame([[1, {LineageId(0, 0)}],
+    expected_lineage_df = DataFrame([[5, {LineageId(0, 3)}],
                                      [2, {LineageId(0, 1)}],
-                                     [5, {LineageId(0, 3)}]],
+                                     [1, {LineageId(0, 0)}]],
                                     columns=['A', 'mlinspect_lineage'])
     pandas.testing.assert_frame_equal(lineage_output.reset_index(drop=True), expected_lineage_df.reset_index(drop=True))
 


### PR DESCRIPTION
Fixes #51 

In joins and selections (and train test split), the iterator creation methods ensure that the rows provided to the inspections are in the order of the operation output and that the input rows are also ordered correctly. This is implemented via joining input and output on the `mlinspect_index`. However, the created row order is currently not correct in all cases.

**Bug description**

In the case of selections that do not keep the row order (for example the sklearn train test split operation that creates unordered random samples) or in the case of joins that order the output based on the join column (option `sort=True`), the row order provided to the inspection is not the row order of the actual operation output. Therefore, the annotations created by the inspection are not ordered correctly.

**Fix description**

The error originates from using the `pandas.merge` function, which by default preserves the order of the *left* join keys (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html). To keep the join result ordered like the output, the output has to be the left DataFrame.

I replaced the `pandas.merge` calls with `DataFrame.merge`, always keeping the DataFrame containing the output on the left side. This ensures that the output order is preserved. Because switching left and right in a join changes the column order, I also rewrote the code calculating and creating the DataFrame slices for iterator creation.

**Alternative fix**

Replacing `pandas.merge` with `DataFrame.merge` is not necessary. Swapping the inputs so that the DataFrame containing the output columns is always left would suffice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.