### PR TITLE
Removal probablity check (Issue #54)

### DIFF
--- a/mlinspect/checks/__init__.py
+++ b/mlinspect/checks/__init__.py
@@ -3,6 +3,8 @@ Packages and classes we want to expose to users
 """
 from ._no_bias_introduced_for import NoBiasIntroducedFor, NoBiasIntroducedForResult
 from ._no_illegal_features import NoIllegalFeatures, NoIllegalFeaturesResult
+from ._similar_removal_probabilities_for import SimilarRemovalProbabilitiesFor, SimilarRemovalProbabilitiesForResult, \
+    RemovalProbabilities
 from ._check import Check, CheckResult, CheckStatus
 
 __all__ = [
@@ -13,4 +15,5 @@ __all__ = [
     # Native checks
     'NoBiasIntroducedFor', 'NoBiasIntroducedForResult',
     'NoIllegalFeatures', 'NoIllegalFeaturesResult',
+    'SimilarRemovalProbabilitiesFor', 'SimilarRemovalProbabilitiesForResult', 'RemovalProbabilities'
 ]

--- a/mlinspect/checks/__init__.py
+++ b/mlinspect/checks/__init__.py
@@ -1,7 +1,7 @@
 """
 Packages and classes we want to expose to users
 """
-from ._no_bias_introduced_for import NoBiasIntroducedFor, NoBiasIntroducedForResult
+from ._no_bias_introduced_for import NoBiasIntroducedFor, NoBiasIntroducedForResult, BiasDistributionChange
 from ._no_illegal_features import NoIllegalFeatures, NoIllegalFeaturesResult
 from ._similar_removal_probabilities_for import SimilarRemovalProbabilitiesFor, SimilarRemovalProbabilitiesForResult, \
     RemovalProbabilities
@@ -13,7 +13,7 @@ __all__ = [
     'CheckResult',
     'CheckStatus',
     # Native checks
-    'NoBiasIntroducedFor', 'NoBiasIntroducedForResult',
+    'NoBiasIntroducedFor', 'NoBiasIntroducedForResult', 'BiasDistributionChange',
     'NoIllegalFeatures', 'NoIllegalFeaturesResult',
     'SimilarRemovalProbabilitiesFor', 'SimilarRemovalProbabilitiesForResult', 'RemovalProbabilities'
 ]

--- a/mlinspect/checks/_similar_removal_probabilities_for.py
+++ b/mlinspect/checks/_similar_removal_probabilities_for.py
@@ -1,0 +1,255 @@
+"""
+The NoBiasIntroducedFor check
+"""
+import dataclasses
+from typing import Iterable, OrderedDict
+import collections
+from matplotlib import pyplot
+from numpy import nanmax
+from pandas import DataFrame
+
+from mlinspect import DagNode, OperatorType
+from mlinspect.checks._check import Check, CheckStatus, CheckResult
+from mlinspect.inspections._histogram_for_columns import HistogramForColumns
+from mlinspect.inspections._inspection import Inspection
+from mlinspect.inspections._inspection_result import InspectionResult
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class RemovalProbabilities:
+    """
+    Did the histogram change too much for one given operation?
+    """
+    dag_node: DagNode
+    acceptable_change: bool
+    acceptable_probability_difference: bool
+    max_probability_difference: float
+    before_and_after_df: DataFrame
+
+
+@dataclasses.dataclass
+class SimilarRemovalProbabilitiesForResult(CheckResult):
+    """
+    Did the histogram change too much for some operations?
+    """
+    bias_distribution_change: OrderedDict[DagNode, OrderedDict[str, RemovalProbabilities]]
+
+
+class SimilarRemovalProbabilitiesFor(Check):
+    """
+    Does the user pipeline introduce bias because of operators like joins and selects?
+    """
+
+    # pylint: disable=unnecessary-pass, too-few-public-methods
+
+    def __init__(self, sensitive_columns, max_allowed_probability_difference=2.0):
+        self.sensitive_columns = sensitive_columns
+        self.max_allowed_probability_difference = max_allowed_probability_difference
+
+    @property
+    def check_id(self):
+        """The id of the Check"""
+        return tuple(self.sensitive_columns), self.max_allowed_probability_difference
+
+    @property
+    def required_inspections(self) -> Iterable[Inspection]:
+        """The inspections required for the check"""
+        return [HistogramForColumns(self.sensitive_columns)]
+
+    def evaluate(self, inspection_result: InspectionResult) -> CheckResult:
+        """Evaluate the check"""
+        dag = inspection_result.dag
+        histograms = inspection_result.inspection_to_annotations[HistogramForColumns(self.sensitive_columns)]
+        relevant_nodes = [node for node in dag.nodes if node.operator_type in {OperatorType.JOIN,
+                                                                               OperatorType.SELECTION} or
+                          (node.module == ('sklearn.impute._base', 'SimpleImputer', 'Pipeline') and
+                           node.columns[0] in self.sensitive_columns)]
+        check_status = CheckStatus.SUCCESS
+        bias_distribution_change = collections.OrderedDict()
+        issue_list = []
+        for node in relevant_nodes:
+            parents = list(dag.predecessors(node))
+            column_results = collections.OrderedDict()
+            for column in self.sensitive_columns:
+                column_result = self.get_histograms_for_node_and_column(column, histograms, node, parents)
+                column_results[column] = column_result
+                if not column_result.acceptable_change:
+                    issue = "A {} causes a min_relative_ratio_change of '{}' by {}, a value below the " \
+                            "configured minimum threshold {}!" \
+                        .format(node.operator_type.value, column, column_result.min_relative_ratio_change,
+                                self.min_allowed_relative_ratio_change)
+                    issue_list.append(issue)
+                    check_status = CheckStatus.FAILURE
+                elif not column_result.acceptable_probability_difference:
+                    issue = "A {} causes a max_probability_difference of '{}' by {}, a value above the " \
+                            "configured maximum threshold {}!" \
+                        .format(node.operator_type.value, column, column_result.max_probability_difference,
+                                self.max_allowed_probability_difference)
+                    issue_list.append(issue)
+                    check_status = CheckStatus.FAILURE
+
+            bias_distribution_change[node] = column_results
+        if issue_list:
+            description = " ".join(issue_list)
+        else:
+            description = None
+        return SimilarRemovalProbabilitiesForResult(self, check_status, description, bias_distribution_change)
+
+    def get_histograms_for_node_and_column(self, column, histograms, node, parents):
+        """
+        Compute histograms for a dag node like a join and a concrete sensitive column like race
+        """
+        # pylint: disable=too-many-locals, too-many-arguments
+        after_map = histograms[node][column]
+        after_df = DataFrame(after_map.items(), columns=["sensitive_column_value", "count_after"])
+
+        before_map = {}
+        for parent in parents:
+            parent_histogram = histograms[parent][column]
+            before_map = {**before_map, **parent_histogram}
+        before_df = DataFrame(before_map.items(), columns=["sensitive_column_value", "count_before"])
+
+        joined_df = before_df.merge(after_df, on="sensitive_column_value", how="outer")
+        joined_df = joined_df.sort_values(by=['sensitive_column_value']).reset_index(drop=True)
+        joined_df["count_before"] = joined_df["count_before"].fillna(0)
+        joined_df["count_after"] = joined_df["count_after"].fillna(0)
+
+        # TODO: What information is useful/what is confusing?
+        # joined_df["absolute_change"] = joined_df["count_after"] - joined_df["count_before"]
+        # joined_df["relative_change"] = joined_df["absolute_change"] / joined_df["count_before"]
+        joined_df["ratio_before"] = joined_df["count_before"] / joined_df["count_before"].sum()
+        joined_df["ratio_after"] = joined_df["count_after"] / joined_df["count_after"].sum()
+        # joined_df["absolute_ratio_change"] = joined_df["ratio_after"] - joined_df["ratio_before"]
+        absolute_ratio_change = joined_df["ratio_after"] - joined_df["ratio_before"]
+        joined_df["relative_ratio_change"] = absolute_ratio_change / joined_df["ratio_before"]
+
+        # Dropping nan values (e.g., missing value imputation) is a distribution change we consider okay
+        not_nan = joined_df["sensitive_column_value"].notnull()
+        min_relative_ratio_change = joined_df[not_nan]["relative_ratio_change"].min()
+        all_changes_acceptable = min_relative_ratio_change >= self.min_allowed_relative_ratio_change
+
+        # Probability of removal
+        joined_df["removed_records"] = joined_df["count_before"] - joined_df["count_after"]
+        joined_df["removal_probability"] = joined_df["removed_records"] / joined_df["count_before"]
+        # There might be classes where no records are being removed.
+        # We should probably find a more principled method to do this at some point
+        non_zero_probabilities = joined_df["removal_probability"] > 0.0
+        removal_probability_min = joined_df[non_zero_probabilities]["removal_probability"].min()
+        joined_df["normalized_removal_probability"] = joined_df["removal_probability"] / removal_probability_min
+        joined_df.loc[joined_df['removed_records'] < 0, 'removal_probability'] = 0
+        joined_df.loc[joined_df['removed_records'] < 0, 'normalized_removal_probability'] = 0
+
+        not_nan = joined_df["normalized_removal_probability"].notnull() & not_nan
+        max_probability_difference = nanmax([joined_df[not_nan]["normalized_removal_probability"].max(), 0.])
+        acceptable_probability_difference = max_probability_difference <= self.max_allowed_probability_difference
+
+        return RemovalProbabilities(node, all_changes_acceptable, min_relative_ratio_change,
+                                    acceptable_probability_difference, max_probability_difference, joined_df)
+
+    @staticmethod
+    def plot_distribution_change_histograms(distribution_change: RemovalProbabilities, filename=None,
+                                            save_to_file=False):
+        """
+        Plot before and after histograms visualising a DistributionChange
+        """
+        pyplot.subplot(1, 2, 1)
+        keys = distribution_change.before_and_after_df["sensitive_column_value"]
+        keys = [str(key) for key in keys]  # Necessary because of null values
+        before_values = distribution_change.before_and_after_df["count_before"]
+        after_values = distribution_change.before_and_after_df["count_after"]
+
+        pyplot.bar(keys, before_values)
+        pyplot.gca().set_title("before")
+        pyplot.xticks(
+            rotation=45,
+            horizontalalignment='right',
+        )
+
+        pyplot.subplot(1, 2, 2)
+
+        pyplot.bar(keys, after_values)
+        pyplot.gca().set_title("after")
+        pyplot.xticks(
+            rotation=45,
+            horizontalalignment='right',
+        )
+
+        fig = pyplot.gcf()
+        fig.set_size_inches(12, 4)
+
+        if save_to_file:
+            fig.savefig(filename + '.svg', bbox_inches='tight')
+            fig.savefig(filename + '.png', bbox_inches='tight', dpi=800)
+
+        pyplot.show()
+        pyplot.close()
+
+    @staticmethod
+    def plot_removal_probability_histograms(distribution_change: RemovalProbabilities, filename=None,
+                                            save_to_file=False):
+        """
+        Plot before and after histograms visualising a DistributionChange
+        """
+        pyplot.subplot(1, 1, 1)
+        keys = distribution_change.before_and_after_df["sensitive_column_value"]
+        keys = [str(key) for key in keys]  # Necessary because of null values
+        removal_probabilities = distribution_change.before_and_after_df["removal_probability"]
+
+        pyplot.bar(keys, removal_probabilities)
+        pyplot.gca().set_title("removal probability per member of sensitive group")
+        pyplot.xticks(
+            rotation=45,
+            horizontalalignment='right',
+        )
+
+        fig = pyplot.gcf()
+        fig.set_size_inches(6, 4)
+
+        if save_to_file:
+            fig.savefig(filename + '.svg', bbox_inches='tight')
+            fig.savefig(filename + '.png', bbox_inches='tight', dpi=800)
+
+        pyplot.show()
+        pyplot.close()
+
+    @staticmethod
+    def get_distribution_changes_overview_as_df(no_bias_check_result: RemovalProbabilities) -> DataFrame:
+        """
+        Get a pandas DataFrame with an overview of all DistributionChanges
+        """
+        # pylint: disable=too-many-locals
+        operator_types = []
+        code_references = []
+        modules = []
+        code_snippets = []
+        descriptions = []
+        assert isinstance(no_bias_check_result.check, SimilarRemovalProbabilitiesFor)
+        sensitive_column_names = []
+        for name in no_bias_check_result.check.sensitive_columns:
+            total_change_column_name = "'{}' distribution change below the configured minimum test threshold" \
+                .format(name)
+            sensitive_column_names.append(total_change_column_name)
+            removal_probability_column_name = "'{}' probability difference above the configured maximum test threshold" \
+                .format(name)
+            sensitive_column_names.append(removal_probability_column_name)
+
+        sensitive_columns = []
+        for _ in range(len(sensitive_column_names)):
+            sensitive_columns.append([])
+        for dag_node, distribution_change in no_bias_check_result.bias_distribution_change.items():
+            operator_types.append(dag_node.operator_type)
+            code_references.append(dag_node.code_reference)
+            modules.append(dag_node.module)
+            code_snippets.append(dag_node.source_code)
+            descriptions.append(dag_node.description)
+            for index, change_info in enumerate(distribution_change.values()):
+                sensitive_columns[2 * index].append(not change_info.acceptable_change)
+                sensitive_columns[2 * index + 1].append(not change_info.acceptable_probability_difference)
+        return DataFrame(zip(operator_types, descriptions, code_references, code_snippets, modules, *sensitive_columns),
+                         columns=[
+                             "operator_type",
+                             "description",
+                             "code_reference",
+                             "source_code",
+                             "module",
+                             *sensitive_column_names])

--- a/mlinspect/testing/_testing_helper_utils.py
+++ b/mlinspect/testing/_testing_helper_utils.py
@@ -10,6 +10,7 @@ from pandas import DataFrame
 from demo.feature_overview.missing_embeddings import MissingEmbeddings
 from mlinspect import OperatorContext, FunctionInfo, OperatorType
 from mlinspect._pipeline_inspector import PipelineInspector
+from mlinspect.checks import SimilarRemovalProbabilitiesFor
 from mlinspect.checks._no_bias_introduced_for import NoBiasIntroducedFor
 from mlinspect.checks._no_illegal_features import NoIllegalFeatures
 from mlinspect.inspections import HistogramForColumns
@@ -245,6 +246,7 @@ def run_and_assert_all_op_outputs_inspected(py_file_path, sensitive_columns, dag
         .on_pipeline_from_py_file(py_file_path) \
         .add_check(NoBiasIntroducedFor(sensitive_columns)) \
         .add_check(NoIllegalFeatures()) \
+        .add_check(SimilarRemovalProbabilitiesFor(sensitive_columns)) \
         .add_required_inspection(MissingEmbeddings(20)) \
         .add_required_inspection(RowLineage(5)) \
         .add_required_inspection(MaterializeFirstOutputRows(5)) \

--- a/test/checks/test_similar_removal_probablities_for.py
+++ b/test/checks/test_similar_removal_probablities_for.py
@@ -10,14 +10,13 @@ from testfixtures import compare
 from mlinspect import DagNode, BasicCodeLocation, OperatorContext, OperatorType, FunctionInfo, DagNodeDetails, \
     OptionalCodeInfo
 from mlinspect._pipeline_inspector import PipelineInspector
-from mlinspect.checks import CheckStatus, NoBiasIntroducedFor, \
-    NoBiasIntroducedForResult
-from mlinspect.checks._no_bias_introduced_for import BiasDistributionChange
-from mlinspect.checks._similar_removal_probabilities_for import SimilarRemovalProbabilitiesFor, RemovalProbabilities
+from mlinspect.checks import CheckStatus
+from mlinspect.checks._similar_removal_probabilities_for import SimilarRemovalProbabilitiesFor, RemovalProbabilities, \
+    SimilarRemovalProbabilitiesForResult
 from mlinspect.instrumentation._dag_node import CodeReference
 
 
-def test_no_bias_introduced_for_merge():
+def test_removal_probab_for_merge():
     """
     Tests whether RowLineage works for joins
     """
@@ -39,7 +38,7 @@ def test_no_bias_introduced_for_merge():
     compare(check_result, expected_result)
 
 
-def test_no_bias_introduced_simple_imputer():
+def test_removal_probab_simple_imputer():
     """
     Tests whether RowLineage works for joins
     """
@@ -63,47 +62,92 @@ def test_no_bias_introduced_simple_imputer():
     compare(check_result, expected_result)
 
 
+def test_removal_probab_dropna():
+    """
+    Tests whether RowLineage works for joins
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+
+            df = pd.DataFrame({'A': ['cat_a', 'cat_a', 'cat_c', 'cat_c', 'cat_c'], 
+                               'B': [None, None, 1, 2, None]})
+            df = df.dropna()
+            """)
+
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_check(SimilarRemovalProbabilitiesFor(['A'])) \
+        .execute()
+
+    check_result = inspector_result.check_to_check_results[SimilarRemovalProbabilitiesFor(['A'])]
+    expected_result = get_expected_check_result_dropna()
+    compare(check_result, expected_result)
+
+
 def get_expected_check_result_merge():
     """ Expected result for the code snippet in test_no_bias_introduced_for_merge"""
-    failing_dag_node = DagNode(2,
-                               BasicCodeLocation('<string-source>', 5),
-                               OperatorContext(OperatorType.JOIN, FunctionInfo('pandas.core.frame', 'merge')),
-                               DagNodeDetails("on 'B'", ['A', 'B', 'C']),
-                               OptionalCodeInfo(CodeReference(5, 12, 5, 36), "df_a.merge(df_b, on='B')"))
+    dag_node = DagNode(2,
+                       BasicCodeLocation('<string-source>', 5),
+                       OperatorContext(OperatorType.JOIN, FunctionInfo('pandas.core.frame', 'merge')),
+                       DagNodeDetails("on 'B'", ['A', 'B', 'C']),
+                       OptionalCodeInfo(CodeReference(5, 12, 5, 36), "df_a.merge(df_b, on='B')"))
 
     change_df = DataFrame({'sensitive_column_value': ['cat_a', 'cat_b', 'cat_c'],
                            'count_before': [2, 2, 1],
                            'count_after': [2, 1, 1],
-                           'ratio_before': [0.4, 0.4, 0.2],
-                           'ratio_after': [0.5, 0.25, 0.25],
-                           'relative_ratio_change': [(0.5 - 0.4) / 0.4, (.25 - 0.4) / 0.4, (0.25 - 0.2) / 0.2]})
-    expected_distribution_change = RemovalProbabilities(failing_dag_node, False, (.25 - 0.4) / 0.4, change_df)
-    expected_dag_node_to_change = {failing_dag_node: {'A': expected_distribution_change}}
-    failure_message = 'A Join causes a min_relative_ratio_change of \'A\' by -0.37500000000000006, a value below the ' \
-                      'configured minimum threshold -0.3!'
-    expected_result = NoBiasIntroducedForResult(NoBiasIntroducedFor(['A']), CheckStatus.FAILURE, failure_message,
-                                                expected_dag_node_to_change)
+                           'removed_records': [0, 1, 0],
+                           'removal_probability': [0., 0.5, 0.],
+                           'normalized_removal_probability': [0., 1., 0.]})
+    expected_probabilities = RemovalProbabilities(dag_node, True, 1., change_df)
+    expected_dag_node_to_change = {dag_node: {'A': expected_probabilities}}
+    failure_message = None
+    expected_result = SimilarRemovalProbabilitiesForResult(SimilarRemovalProbabilitiesFor(['A']), CheckStatus.SUCCESS,
+                                                           failure_message, expected_dag_node_to_change)
     return expected_result
 
 
 def get_expected_check_result_simple_imputer():
     """ Expected result for the code snippet in test_no_bias_introduced_for_simple_imputer"""
-    imputer_dag_node = DagNode(1,
-                               BasicCodeLocation('<string-source>', 6),
-                               OperatorContext(OperatorType.TRANSFORMER,
-                                               FunctionInfo('sklearn.impute._base', 'SimpleImputer')),
-                               DagNodeDetails('Simple Imputer', ['A']),
-                               OptionalCodeInfo(CodeReference(6, 10, 6, 72),
-                                                "SimpleImputer(missing_values=np.nan, strategy='most_frequent')"))
+    dag_node = DagNode(1,
+                       BasicCodeLocation('<string-source>', 6),
+                       OperatorContext(OperatorType.TRANSFORMER,
+                                       FunctionInfo('sklearn.impute._base', 'SimpleImputer')),
+                       DagNodeDetails('Simple Imputer', ['A']),
+                       OptionalCodeInfo(CodeReference(6, 10, 6, 72),
+                                        "SimpleImputer(missing_values=np.nan, strategy='most_frequent')"))
 
     change_df = DataFrame({'sensitive_column_value': ['cat_a', 'cat_c', math.nan],
                            'count_before': [2, 1, 1],
                            'count_after': [3, 1, 0],
-                           'ratio_before': [0.5, 0.25, 0.25],
-                           'ratio_after': [0.75, 0.25, 0.],
-                           'relative_ratio_change': [0.5, 0., -1.]})
-    expected_distribution_change = BiasDistributionChange(imputer_dag_node, True, 0., change_df)
-    expected_dag_node_to_change = {imputer_dag_node: {'A': expected_distribution_change}}
-    expected_result = NoBiasIntroducedForResult(NoBiasIntroducedFor(['A']), CheckStatus.SUCCESS, None,
-                                                expected_dag_node_to_change)
+                           'removed_records': [-1, 0, 1],
+                           'removal_probability': [0., 0., 1.],
+                           'normalized_removal_probability': [0., 0., 1.]})
+    expected_probabilities = RemovalProbabilities(dag_node, True, 0., change_df)
+    expected_dag_node_to_change = {dag_node: {'A': expected_probabilities}}
+    failure_message = None
+    expected_result = SimilarRemovalProbabilitiesForResult(SimilarRemovalProbabilitiesFor(['A']), CheckStatus.SUCCESS,
+                                                           failure_message, expected_dag_node_to_change)
+    return expected_result
+
+
+def get_expected_check_result_dropna():
+    """ Expected result for the code snippet in test_no_bias_introduced_for_dropna"""
+    dag_node = DagNode(1,
+                       BasicCodeLocation('<string-source>', 5),
+                       OperatorContext(OperatorType.SELECTION, FunctionInfo('pandas.core.frame', 'dropna')),
+                       DagNodeDetails("dropna", ['A', 'B']),
+                       OptionalCodeInfo(CodeReference(5, 5, 5, 16), "df.dropna()"))
+
+    change_df = DataFrame({'sensitive_column_value': ['cat_a', 'cat_c'],
+                           'count_before': [2, 3],
+                           'count_after': [0, 2],
+                           'removed_records': [2, 1],
+                           'removal_probability': [1., 1. / 3.],
+                           'normalized_removal_probability': [3., 1.]})
+    expected_probabilities = RemovalProbabilities(dag_node, False, 3., change_df)
+    expected_dag_node_to_change = {dag_node: {'A': expected_probabilities}}
+    failure_message = "A Selection causes a max_probability_difference of 'A' by 3.0, a value above the configured " \
+                      "maximum threshold 2.0!"
+    expected_result = SimilarRemovalProbabilitiesForResult(SimilarRemovalProbabilitiesFor(['A']), CheckStatus.FAILURE,
+                                                           failure_message, expected_dag_node_to_change)
     return expected_result

--- a/test/checks/test_similar_removal_probablities_for.py
+++ b/test/checks/test_similar_removal_probablities_for.py
@@ -1,0 +1,109 @@
+"""
+Tests whether NoMissingEmbeddings works
+"""
+import math
+from inspect import cleandoc
+
+from pandas import DataFrame
+from testfixtures import compare
+
+from mlinspect import DagNode, BasicCodeLocation, OperatorContext, OperatorType, FunctionInfo, DagNodeDetails, \
+    OptionalCodeInfo
+from mlinspect._pipeline_inspector import PipelineInspector
+from mlinspect.checks import CheckStatus, NoBiasIntroducedFor, \
+    NoBiasIntroducedForResult
+from mlinspect.checks._no_bias_introduced_for import BiasDistributionChange
+from mlinspect.checks._similar_removal_probabilities_for import SimilarRemovalProbabilitiesFor, RemovalProbabilities
+from mlinspect.instrumentation._dag_node import CodeReference
+
+
+def test_no_bias_introduced_for_merge():
+    """
+    Tests whether RowLineage works for joins
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+
+            df_a = pd.DataFrame({'A': ['cat_a', 'cat_b', 'cat_a', 'cat_c', 'cat_b'], 'B': [1, 2, 4, 5, 7]})
+            df_b = pd.DataFrame({'B': [1, 2, 3, 4, 5], 'C': [1, 5, 4, 11, None]})
+            df_merged = df_a.merge(df_b, on='B')
+            """)
+
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_check(SimilarRemovalProbabilitiesFor(['A'])) \
+        .execute()
+
+    check_result = inspector_result.check_to_check_results[SimilarRemovalProbabilitiesFor(['A'])]
+    expected_result = get_expected_check_result_merge()
+    compare(check_result, expected_result)
+
+
+def test_no_bias_introduced_simple_imputer():
+    """
+    Tests whether RowLineage works for joins
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+            from sklearn.impute import SimpleImputer
+            import numpy as np
+
+            df = pd.DataFrame({'A': ['cat_a', np.nan, 'cat_a', 'cat_c']})
+            imputer = SimpleImputer(missing_values=np.nan, strategy='most_frequent')
+            imputed_data = imputer.fit_transform(df)
+            """)
+
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_check(SimilarRemovalProbabilitiesFor(['A'])) \
+        .execute()
+
+    check_result = inspector_result.check_to_check_results[SimilarRemovalProbabilitiesFor(['A'])]
+    expected_result = get_expected_check_result_simple_imputer()
+    compare(check_result, expected_result)
+
+
+def get_expected_check_result_merge():
+    """ Expected result for the code snippet in test_no_bias_introduced_for_merge"""
+    failing_dag_node = DagNode(2,
+                               BasicCodeLocation('<string-source>', 5),
+                               OperatorContext(OperatorType.JOIN, FunctionInfo('pandas.core.frame', 'merge')),
+                               DagNodeDetails("on 'B'", ['A', 'B', 'C']),
+                               OptionalCodeInfo(CodeReference(5, 12, 5, 36), "df_a.merge(df_b, on='B')"))
+
+    change_df = DataFrame({'sensitive_column_value': ['cat_a', 'cat_b', 'cat_c'],
+                           'count_before': [2, 2, 1],
+                           'count_after': [2, 1, 1],
+                           'ratio_before': [0.4, 0.4, 0.2],
+                           'ratio_after': [0.5, 0.25, 0.25],
+                           'relative_ratio_change': [(0.5 - 0.4) / 0.4, (.25 - 0.4) / 0.4, (0.25 - 0.2) / 0.2]})
+    expected_distribution_change = RemovalProbabilities(failing_dag_node, False, (.25 - 0.4) / 0.4, change_df)
+    expected_dag_node_to_change = {failing_dag_node: {'A': expected_distribution_change}}
+    failure_message = 'A Join causes a min_relative_ratio_change of \'A\' by -0.37500000000000006, a value below the ' \
+                      'configured minimum threshold -0.3!'
+    expected_result = NoBiasIntroducedForResult(NoBiasIntroducedFor(['A']), CheckStatus.FAILURE, failure_message,
+                                                expected_dag_node_to_change)
+    return expected_result
+
+
+def get_expected_check_result_simple_imputer():
+    """ Expected result for the code snippet in test_no_bias_introduced_for_simple_imputer"""
+    imputer_dag_node = DagNode(1,
+                               BasicCodeLocation('<string-source>', 6),
+                               OperatorContext(OperatorType.TRANSFORMER,
+                                               FunctionInfo('sklearn.impute._base', 'SimpleImputer')),
+                               DagNodeDetails('Simple Imputer', ['A']),
+                               OptionalCodeInfo(CodeReference(6, 10, 6, 72),
+                                                "SimpleImputer(missing_values=np.nan, strategy='most_frequent')"))
+
+    change_df = DataFrame({'sensitive_column_value': ['cat_a', 'cat_c', math.nan],
+                           'count_before': [2, 1, 1],
+                           'count_after': [3, 1, 0],
+                           'ratio_before': [0.5, 0.25, 0.25],
+                           'ratio_after': [0.75, 0.25, 0.],
+                           'relative_ratio_change': [0.5, 0., -1.]})
+    expected_distribution_change = BiasDistributionChange(imputer_dag_node, True, 0., change_df)
+    expected_dag_node_to_change = {imputer_dag_node: {'A': expected_distribution_change}}
+    expected_result = NoBiasIntroducedForResult(NoBiasIntroducedFor(['A']), CheckStatus.SUCCESS, None,
+                                                expected_dag_node_to_change)
+    return expected_result

--- a/test/checks/test_similar_removal_probablities_for.py
+++ b/test/checks/test_similar_removal_probablities_for.py
@@ -4,6 +4,7 @@ Tests whether NoMissingEmbeddings works
 import math
 from inspect import cleandoc
 
+import matplotlib
 import pandas
 from pandas import DataFrame
 from testfixtures import compare
@@ -94,6 +95,7 @@ def test_removal_probab_dropna():
         "'A' probability difference below the configured maximum test threshold": [True]
     })
     pandas.testing.assert_frame_equal(overview, expected_df)
+    matplotlib.use("template")  # Disable plt.show when executing nb as part of this test
     SimilarRemovalProbabilitiesFor.plot_removal_probability_histograms(
         list(check_result.removal_probability_change.values())[0]['A'])
     SimilarRemovalProbabilitiesFor.plot_distribution_change_histograms(


### PR DESCRIPTION
*Issue #, if available:* #54

*Description of changes:*
* Added a new check that is based on computing removal probabilities of different sensitive groups in the data
* It will raise an alarm if filters change the group counts from multiple groups but do not treat the different groups similarly
* This check is still very experimental, and will likely require some tweaking of the mechanism as we get more experience with it


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
