### PR TITLE
IntersectionalHistogramForColumns (Issue #56)

### DIFF
--- a/mlinspect/inspections/__init__.py
+++ b/mlinspect/inspections/__init__.py
@@ -6,6 +6,7 @@ from ._inspection_result import InspectionResult
 from ._inspection_input import InspectionInputUnaryOperator, InspectionInputDataSource, InspectionInputSinkOperator, \
     InspectionInputNAryOperator
 from ._histogram_for_columns import HistogramForColumns
+from ._intersectional_histogram_for_columns import IntersectionalHistogramForColumns
 from ._lineage import RowLineage
 from ._materialize_first_output_rows import MaterializeFirstOutputRows
 
@@ -16,6 +17,7 @@ __all__ = [
     'InspectionInputNAryOperator',
     # Native inspections
     'HistogramForColumns',
+    'IntersectionalHistogramForColumns',
     'RowLineage',
     'MaterializeFirstOutputRows'
 ]

--- a/mlinspect/inspections/_histogram_for_columns.py
+++ b/mlinspect/inspections/_histogram_for_columns.py
@@ -10,7 +10,7 @@ from mlinspect.inspections._inspection_input import InspectionInputDataSource, \
 
 class HistogramForColumns(Inspection):
     """
-    A simple example inspection
+    An inspection to compute group membership histograms for multiple columns
     """
 
     def __init__(self, sensitive_columns):

--- a/mlinspect/inspections/_intersectional_histogram_for_columns.py
+++ b/mlinspect/inspections/_intersectional_histogram_for_columns.py
@@ -10,7 +10,7 @@ from mlinspect.inspections._inspection_input import InspectionInputDataSource, \
 
 class IntersectionalHistogramForColumns(Inspection):
     """
-    A simple example inspection
+    An inspection to compute intersectional group memberships
     """
 
     def __init__(self, sensitive_columns: List[str]):

--- a/mlinspect/inspections/_intersectional_histogram_for_columns.py
+++ b/mlinspect/inspections/_intersectional_histogram_for_columns.py
@@ -1,0 +1,128 @@
+"""
+A simple example inspection
+"""
+from typing import Iterable, List
+
+from mlinspect.inspections._inspection import Inspection
+from mlinspect.inspections._inspection_input import InspectionInputDataSource, \
+    InspectionInputUnaryOperator, InspectionInputNAryOperator, OperatorType, FunctionInfo
+
+
+class IntersectionalHistogramForColumns(Inspection):
+    """
+    A simple example inspection
+    """
+
+    def __init__(self, sensitive_columns: List[str]):
+        self._histogram_op_output = None
+        self._operator_type = None
+        self.sensitive_columns = sensitive_columns
+
+    @property
+    def inspection_id(self):
+        return tuple(self.sensitive_columns)
+
+    def visit_operator(self, inspection_input) -> Iterable[any]:
+        """
+        Visit an operator
+        """
+        # pylint: disable=too-many-branches, too-many-statements, too-many-locals
+        current_count = - 1
+
+        histogram_map = {}
+
+        self._operator_type = inspection_input.operator_context.operator
+
+        if isinstance(inspection_input, InspectionInputUnaryOperator):
+            sensitive_columns_present = []
+            sensitive_columns_index = []
+            for column in self.sensitive_columns:
+                column_present = column in inspection_input.input_columns.fields
+                sensitive_columns_present.append(column_present)
+                column_index = inspection_input.input_columns.get_index_of_column(column)
+                sensitive_columns_index.append(column_index)
+            if inspection_input.operator_context.function_info == FunctionInfo('sklearn.impute._base', 'SimpleImputer'):
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    column_values = []
+                    for check_index, _ in enumerate(self.sensitive_columns):
+                        if sensitive_columns_present[check_index]:
+                            column_value = row.output[0][sensitive_columns_index[check_index]]
+                        else:
+                            column_value = row.annotation[check_index]
+                        column_values.append(column_value)
+                    update_histograms(column_values, histogram_map)
+                    yield column_values
+            else:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    column_values = []
+                    for check_index, _ in enumerate(self.sensitive_columns):
+                        if sensitive_columns_present[check_index]:
+                            column_value = row.input[sensitive_columns_index[check_index]]
+                        else:
+                            column_value = row.annotation[check_index]
+                        column_values.append(column_value)
+                    update_histograms(column_values, histogram_map)
+                    yield column_values
+        elif isinstance(inspection_input, InspectionInputDataSource):
+            sensitive_columns_present = []
+            sensitive_columns_index = []
+            for column in self.sensitive_columns:
+                column_present = column in inspection_input.output_columns.fields
+                sensitive_columns_present.append(column_present)
+                column_index = inspection_input.output_columns.get_index_of_column(column)
+                sensitive_columns_index.append(column_index)
+            for row in inspection_input.row_iterator:
+                current_count += 1
+                column_values = []
+                for check_index, _ in enumerate(self.sensitive_columns):
+                    if sensitive_columns_present[check_index]:
+                        column_value = row.output[sensitive_columns_index[check_index]]
+                        column_values.append(column_value)
+                    else:
+                        column_values.append(None)
+                update_histograms(column_values, histogram_map)
+                yield column_values
+        elif isinstance(inspection_input, InspectionInputNAryOperator):
+            sensitive_columns_present = []
+            sensitive_columns_index = []
+            for column in self.sensitive_columns:
+                column_present = column in inspection_input.output_columns.fields
+                sensitive_columns_present.append(column_present)
+                column_index = inspection_input.output_columns.get_index_of_column(column)
+                sensitive_columns_index.append(column_index)
+            for row in inspection_input.row_iterator:
+                current_count += 1
+                column_values = []
+                for check_index, _ in enumerate(self.sensitive_columns):
+                    if sensitive_columns_present[check_index]:
+                        column_value = row.output[sensitive_columns_index[check_index]]
+                        column_values.append(column_value)
+                    else:
+                        column_values.append(None)
+                update_histograms(column_values, histogram_map)
+                yield column_values
+        else:
+            for _ in inspection_input.row_iterator:
+                yield None
+
+        self._histogram_op_output = histogram_map
+
+    def get_operator_annotation_after_visit(self) -> any:
+        assert self._operator_type
+        if self._operator_type is not OperatorType.ESTIMATOR:
+            result = self._histogram_op_output
+            self._histogram_op_output = None
+            self._operator_type = None
+            return result
+        self._operator_type = None
+        return None
+
+
+def update_histograms(column_values, histogram_map):
+    """Update the histograms with the intersectional information"""
+    value_tuple = tuple(column_values)
+    group_count = histogram_map.get(value_tuple, 0)
+    group_count += 1
+    histogram_map[value_tuple] = group_count

--- a/mlinspect/testing/_testing_helper_utils.py
+++ b/mlinspect/testing/_testing_helper_utils.py
@@ -13,7 +13,7 @@ from mlinspect._pipeline_inspector import PipelineInspector
 from mlinspect.checks import SimilarRemovalProbabilitiesFor
 from mlinspect.checks._no_bias_introduced_for import NoBiasIntroducedFor
 from mlinspect.checks._no_illegal_features import NoIllegalFeatures
-from mlinspect.inspections import HistogramForColumns
+from mlinspect.inspections import HistogramForColumns, IntersectionalHistogramForColumns
 from mlinspect.inspections._lineage import RowLineage
 from mlinspect.inspections._materialize_first_output_rows import MaterializeFirstOutputRows
 from mlinspect.instrumentation._dag_node import DagNode, CodeReference, BasicCodeLocation, DagNodeDetails, \
@@ -250,6 +250,7 @@ def run_and_assert_all_op_outputs_inspected(py_file_path, sensitive_columns, dag
         .add_required_inspection(MissingEmbeddings(20)) \
         .add_required_inspection(RowLineage(5)) \
         .add_required_inspection(MaterializeFirstOutputRows(5)) \
+        .add_required_inspection(IntersectionalHistogramForColumns(sensitive_columns)) \
         .add_custom_monkey_patching_modules(custom_monkey_patching) \
         .execute()
 
@@ -263,10 +264,12 @@ def run_and_assert_all_op_outputs_inspected(py_file_path, sensitive_columns, dag
             assert inspection_result[MaterializeFirstOutputRows(5)] is not None
             assert inspection_result[RowLineage(5)] is not None
             assert inspection_result[HistogramForColumns(sensitive_columns)] is not None
+            assert inspection_result[IntersectionalHistogramForColumns(sensitive_columns)] is not None
         else:
             assert inspection_result[MaterializeFirstOutputRows(5)] is None
             assert inspection_result[RowLineage(5)] is not None
             assert inspection_result[HistogramForColumns(sensitive_columns)] is None
+            assert inspection_result[IntersectionalHistogramForColumns(sensitive_columns)] is None
 
     save_fig_to_path(inspector_result.dag, dag_png_path)
     assert os.path.isfile(dag_png_path)

--- a/test/inspections/test_histogram_for_columns.py
+++ b/test/inspections/test_histogram_for_columns.py
@@ -11,7 +11,7 @@ from mlinspect.inspections import HistogramForColumns
 
 def test_histogram_merge():
     """
-    Tests whether RowLineage works for joins
+    Tests whether HistogramForColumns works for joins
     """
     test_code = cleandoc("""
             import pandas as pd
@@ -42,7 +42,7 @@ def test_histogram_merge():
 
 def test_histogram_projection():
     """
-    Tests whether RowLineage works for joins
+    Tests whether HistogramForColumns works for projections
     """
     test_code = cleandoc("""
             import pandas as pd

--- a/test/inspections/test_intersectional_histogram_for_columns.py
+++ b/test/inspections/test_intersectional_histogram_for_columns.py
@@ -1,0 +1,74 @@
+"""
+Tests whether HistogramForColumns works
+"""
+from inspect import cleandoc
+
+from testfixtures import compare
+
+from mlinspect._pipeline_inspector import PipelineInspector
+from mlinspect.inspections import IntersectionalHistogramForColumns
+
+
+def test_histogram_merge():
+    """
+    Tests whether RowLineage works for joins
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+
+            df_a = pd.DataFrame({'A': ['cat_a', 'cat_b', 'cat_a', 'cat_b', 'cat_b'], 
+                'B': [1, 2, 4, 5, 7],
+                'C': [True, False, True, True, True]})
+            df_b = pd.DataFrame({'B': [1, 2, 3, 4, 5], 'D': [1, 5, 4, 11, None]})
+            df_merged = df_a.merge(df_b, on='B')
+            """)
+
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_required_inspection(IntersectionalHistogramForColumns(["A", "C"])) \
+        .execute()
+    inspection_results = list(inspector_result.dag_node_to_inspection_results.values())
+
+    histogram_output = inspection_results[0][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {('cat_a', True): 2, ('cat_b', False): 1, ('cat_b', True): 2}
+    compare(histogram_output, expected_histogram)
+
+    histogram_output = inspection_results[1][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {(None, None): 5}
+    compare(histogram_output, expected_histogram)
+
+    histogram_output = inspection_results[2][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {('cat_a', True): 2, ('cat_b', False): 1, ('cat_b', True): 1}
+    compare(histogram_output, expected_histogram)
+
+
+def test_histogram_projection():
+    """
+    Tests whether RowLineage works for joins
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+
+            pandas_df = pd.DataFrame({'A': ['cat_a', 'cat_b', 'cat_a', 'cat_c', 'cat_b'], 
+                'B': [1, 2, 4, 5, 7], 'C': [True, False, True, True, True]})
+            pandas_df = pandas_df[['B', 'C']]
+            pandas_df = pandas_df[['C']]
+            """)
+
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_required_inspection(IntersectionalHistogramForColumns(["A", "C"])) \
+        .execute()
+    inspection_results = list(inspector_result.dag_node_to_inspection_results.values())
+
+    histogram_output = inspection_results[0][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {('cat_a', True): 2, ('cat_b', False): 1, ('cat_c', True): 1, ('cat_b', True): 1}
+    compare(histogram_output, expected_histogram)
+
+    histogram_output = inspection_results[1][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {('cat_a', True): 2, ('cat_b', False): 1, ('cat_c', True): 1, ('cat_b', True): 1}
+    compare(histogram_output, expected_histogram)
+
+    histogram_output = inspection_results[2][IntersectionalHistogramForColumns(["A", "C"])]
+    expected_histogram = {('cat_a', True): 2, ('cat_b', False): 1, ('cat_c', True): 1, ('cat_b', True): 1}
+    compare(histogram_output, expected_histogram)

--- a/test/inspections/test_intersectional_histogram_for_columns.py
+++ b/test/inspections/test_intersectional_histogram_for_columns.py
@@ -11,7 +11,7 @@ from mlinspect.inspections import IntersectionalHistogramForColumns
 
 def test_histogram_merge():
     """
-    Tests whether RowLineage works for joins
+    Tests whether IntersectionalHistogramForColumns works for joins
     """
     test_code = cleandoc("""
             import pandas as pd
@@ -44,7 +44,7 @@ def test_histogram_merge():
 
 def test_histogram_projection():
     """
-    Tests whether RowLineage works for joins
+    Tests whether IntersectionalHistogramForColumns works for projections
     """
     test_code = cleandoc("""
             import pandas as pd


### PR DESCRIPTION
*Issue #, if available:* #56

*Description of changes:*
* Implemented a simple inspection to compute histograms for intersectional group memberships
* For now, we do not have special treatment of the label column like the histograms for the fairDAGs paper. We will need to think further about how to do this cleanly and consistently throughout the pipeline when the label column is transformed at some point in the pipeline (e.g., using `label_binarize` or a `LabelEncoder`).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
