### PR TITLE
Support HashingVectorizer (Issue #71)

### DIFF
--- a/mlinspect/monkeypatching/README.md
+++ b/mlinspect/monkeypatching/README.md
@@ -74,6 +74,7 @@ compare(networkx.to_dict_of_dicts(extracted_dag), networkx.to_dict_of_dicts(expe
 | `('sklearn.preprocessing._encoders', 'OneHotEncoder')`, arg type: strings | Transformer |
 | `('sklearn.preprocessing._data', 'StandardScaler')` | Transformer      |
 | `('sklearn.impute._base’, 'SimpleImputer')` | Transformer      |
+| `('sklearn.feature_extraction.text’, 'HashingVectorizer')` | Transformer      |
 | `('sklearn.preprocessing._discretization', 'KBinsDiscretizer')` | Transformer      |
 | `('sklearn.preprocessing_function_transformer','FunctionTransformer')` | Transformer      |
 | `('sklearn.tree._classes', 'DecisionTreeClassifier')` | Estimator      |

--- a/mlinspect/monkeypatching/_patch_pandas.py
+++ b/mlinspect/monkeypatching/_patch_pandas.py
@@ -396,6 +396,10 @@ class LocIndexerPatching:
                     and isinstance(args[0][1], list) and isinstance(args[0][1][0], str):
                 # Projection to one or multiple columns, return value is df
                 columns = args[0][1]
+            elif isinstance(args[0], tuple) and not args[0][0].start and not args[0][0].stop \
+                    and isinstance(args[0][1], str):
+                # Projection to one column with str syntax, e.g., for HashingVectorizer
+                columns = [args[0][1]]
             else:
                 raise NotImplementedError()
 

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -7,6 +7,7 @@ import gorilla
 import numpy
 import pandas
 from sklearn import preprocessing, compose, tree, impute, linear_model, model_selection
+from sklearn.feature_extraction import text
 from sklearn.linear_model._stochastic_gradient import DEFAULT_EPSILON
 from tensorflow.keras.wrappers import scikit_learn as keras_sklearn_external  # pylint: disable=no-name-in-module
 from tensorflow.python.keras.wrappers import scikit_learn as keras_sklearn_internal  # pylint: disable=no-name-in-module
@@ -333,6 +334,108 @@ class SklearnStandardScalerPatching:
                                BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
                                operator_context,
                                DagNodeDetails("Standard Scaler: transform", ['array']),
+                               get_optional_code_info_or_none(self.mlinspect_optional_code_reference,
+                                                              self.mlinspect_optional_source_code))
+            add_dag_node(dag_node, [input_info.dag_node], backend_result)
+        else:
+            new_return_value = original(self, *args, **kwargs)
+        return new_return_value
+
+
+@gorilla.patches(text.HashingVectorizer)
+class SklearnHasingVectorizerPatching:
+    """ Patches for sklearn StandardScaler"""
+
+    # pylint: disable=too-few-public-methods, redefined-builtin, too-many-locals
+
+    @gorilla.name('__init__')
+    @gorilla.settings(allow_hit=True)
+    def patched__init__(self, *, input='content', encoding='utf-8', decode_error='strict', strip_accents=None,
+                        lowercase=True, preprocessor=None, tokenizer=None, stop_words=None,
+                        token_pattern=r"(?u)\b\w\w+\b", ngram_range=(1, 1), analyzer='word', n_features=(2 ** 20),
+                        binary=False, norm='l2', alternate_sign=True, dtype=numpy.float64,
+                        mlinspect_caller_filename=None, mlinspect_lineno=None,
+                        mlinspect_optional_code_reference=None, mlinspect_optional_source_code=None,
+                        mlinspect_fit_transform_active=False):
+        """ Patch for ('sklearn.feature_extraction.text', 'HashingVectorizer') """
+        # pylint: disable=no-method-argument, attribute-defined-outside-init
+        original = gorilla.get_original_attribute(text.HashingVectorizer, '__init__')
+
+        self.mlinspect_caller_filename = mlinspect_caller_filename
+        self.mlinspect_lineno = mlinspect_lineno
+        self.mlinspect_optional_code_reference = mlinspect_optional_code_reference
+        self.mlinspect_optional_source_code = mlinspect_optional_source_code
+        self.mlinspect_fit_transform_active = mlinspect_fit_transform_active
+
+        def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
+            """ Execute inspections, add DAG node """
+            original(self, input=input, encoding=encoding, decode_error=decode_error, strip_accents=strip_accents,
+                     lowercase=lowercase, preprocessor=preprocessor, tokenizer=tokenizer, stop_words=stop_words,
+                     token_pattern=token_pattern, ngram_range=ngram_range, analyzer=analyzer, n_features=n_features,
+                     binary=binary, norm=norm, alternate_sign=alternate_sign, dtype=dtype)
+
+            self.mlinspect_caller_filename = caller_filename
+            self.mlinspect_lineno = lineno
+            self.mlinspect_optional_code_reference = optional_code_reference
+            self.mlinspect_optional_source_code = optional_source_code
+
+        return execute_patched_func_no_op_id(original, execute_inspections, self, input=input, encoding=encoding,
+                                             decode_error=decode_error, strip_accents=strip_accents,
+                                             lowercase=lowercase, preprocessor=preprocessor, tokenizer=tokenizer,
+                                             stop_words=stop_words, token_pattern=token_pattern,
+                                             ngram_range=ngram_range, analyzer=analyzer, n_features=n_features,
+                                             binary=binary, norm=norm, alternate_sign=alternate_sign, dtype=dtype)
+
+    @gorilla.name('fit_transform')
+    @gorilla.settings(allow_hit=True)
+    def patched_fit_transform(self, *args, **kwargs):
+        """ Patch for ('sklearn.feature_extraction.text.HashingVectorizer', 'fit_transform') """
+        # pylint: disable=no-method-argument
+        self.mlinspect_fit_transform_active = True  # pylint: disable=attribute-defined-outside-init
+        original = gorilla.get_original_attribute(text.HashingVectorizer, 'fit_transform')
+        function_info = FunctionInfo('sklearn.feature_extraction.text', 'HashingVectorizer')
+        input_info = get_input_info(args[0], self.mlinspect_caller_filename, self.mlinspect_lineno, function_info,
+                                    self.mlinspect_optional_code_reference, self.mlinspect_optional_source_code)
+
+        operator_context = OperatorContext(OperatorType.TRANSFORMER, function_info)
+        input_infos = SklearnBackend.before_call(operator_context, [input_info.annotated_dfobject])
+        result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
+        backend_result = SklearnBackend.after_call(operator_context,
+                                                   input_infos,
+                                                   result)
+        new_return_value = backend_result.annotated_dfobject.result_data
+        dag_node = DagNode(singleton.get_next_op_id(),
+                           BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
+                           operator_context,
+                           DagNodeDetails("Hashing Vectorizer: fit_transform", ['array']),
+                           get_optional_code_info_or_none(self.mlinspect_optional_code_reference,
+                                                          self.mlinspect_optional_source_code))
+        add_dag_node(dag_node, [input_info.dag_node], backend_result)
+        self.mlinspect_fit_transform_active = False  # pylint: disable=attribute-defined-outside-init
+        return new_return_value
+
+    @gorilla.name('transform')
+    @gorilla.settings(allow_hit=True)
+    def patched_transform(self, *args, **kwargs):
+        """ Patch for ('sklearn.preprocessing._data.StandardScaler', 'transform') """
+        # pylint: disable=no-method-argument
+        original = gorilla.get_original_attribute(text.HashingVectorizer, 'transform')
+        if not self.mlinspect_fit_transform_active:
+            function_info = FunctionInfo('sklearn.feature_extraction.text', 'HashingVectorizer')
+            input_info = get_input_info(args[0], self.mlinspect_caller_filename, self.mlinspect_lineno, function_info,
+                                        self.mlinspect_optional_code_reference, self.mlinspect_optional_source_code)
+
+            operator_context = OperatorContext(OperatorType.TRANSFORMER, function_info)
+            input_infos = SklearnBackend.before_call(operator_context, [input_info.annotated_dfobject])
+            result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
+            backend_result = SklearnBackend.after_call(operator_context,
+                                                       input_infos,
+                                                       result)
+            new_return_value = backend_result.annotated_dfobject.result_data
+            dag_node = DagNode(singleton.get_next_op_id(),
+                               BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
+                               operator_context,
+                               DagNodeDetails("Hashing Vectorizer: transform", ['array']),
                                get_optional_code_info_or_none(self.mlinspect_optional_code_reference,
                                                               self.mlinspect_optional_source_code))
             add_dag_node(dag_node, [input_info.dag_node], backend_result)


### PR DESCRIPTION
*Issue #, if available:* #71

*Description of changes:*
* Add support for `HashingVectorizer`
* Add support for selections of single columns in the `ColumnTransformer` using a single `str` instead of a `List[str]`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
