### PR TITLE
RowLineage: Full Output For Op-Types  (Issue #79)

### DIFF
--- a/mlinspect/inspections/_lineage.py
+++ b/mlinspect/inspections/_lineage.py
@@ -41,7 +41,7 @@ class RowLineage(Inspection):
         else:
             self.operator_type_restriction = None
             self._inspection_id = self.row_count
-        self._operator_count = 0
+        self._operator_count = -1
         self._op_output = None
         self._op_lineage = None
         self._output_columns = None

--- a/mlinspect/inspections/_lineage.py
+++ b/mlinspect/inspections/_lineage.py
@@ -2,7 +2,7 @@
 A simple inspection for lineage tracking
 """
 import dataclasses
-from typing import Iterable
+from typing import Iterable, List
 
 from pandas import DataFrame, Series
 
@@ -29,25 +29,35 @@ class RowLineage(Inspection):
     #  in a set and then it is enough to check for set memberships in InspectionInputDataSource inspection inputs.
     #  This set membership can be used as a 'materialize' flag we use as annotation. Then we simply need to check this
     #  flag to check whether to materialize rows.
+    # pylint: disable=too-many-instance-attributes
 
     ALL_ROWS = -1
 
-    def __init__(self, row_count: int):
+    def __init__(self, row_count: int, operator_type_restriction: List[OperatorType] = None):
         self.row_count = row_count
-        self._inspection_id = self.row_count
-
+        if operator_type_restriction is not None:
+            self.operator_type_restriction = set(operator_type_restriction)
+            self._inspection_id = (self.row_count, *self.operator_type_restriction)
+        else:
+            self.operator_type_restriction = None
+            self._inspection_id = (self.row_count)
         self._operator_count = 0
         self._op_output = None
         self._op_lineage = None
         self._output_columns = None
         self._is_sink = False
+        self._materialize_for_this_operator = None
 
     def visit_operator(self, inspection_input) -> Iterable[any]:
         """Visit an operator, generate row index number annotations and check whether they get propagated correctly"""
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches, too-many-statements
         operator_output = []
         operator_lineage = []
         current_count = -1
+
+        materialize_for_this_operator = (self.operator_type_restriction is None) or \
+                                        (inspection_input.operator_context.operator
+                                         in self.operator_type_restriction)
 
         if not isinstance(inspection_input, InspectionInputSinkOperator):
             self._output_columns = inspection_input.output_columns.fields
@@ -55,17 +65,36 @@ class RowLineage(Inspection):
             self._is_sink = True
 
         if isinstance(inspection_input, InspectionInputDataSource):
-            for row in inspection_input.row_iterator:
-                current_count += 1
-                annotation = {LineageId(self._operator_count, current_count)}
-                if current_count < self.row_count:
+            if materialize_for_this_operator and self.row_count == RowLineage.ALL_ROWS:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = {LineageId(self._operator_count, current_count)}
                     operator_output.append(row.output)
                     operator_lineage.append(annotation)
-                yield annotation
+                    yield annotation
+            elif materialize_for_this_operator:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = {LineageId(self._operator_count, current_count)}
+                    if current_count < self.row_count:
+                        operator_output.append(row.output)
+                        operator_lineage.append(annotation)
+                    yield annotation
+            else:
+                for _ in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = {LineageId(self._operator_count, current_count)}
+                    yield annotation
+        elif isinstance(inspection_input, InspectionInputNAryOperator):
+            if materialize_for_this_operator and self.row_count == RowLineage.ALL_ROWS:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
 
-        elif isinstance(inspection_input, (InspectionInputNAryOperator, InspectionInputSinkOperator)):
-            if inspection_input.operator_context.operator in {OperatorType.JOIN, OperatorType.SCORE,
-                                                              OperatorType.CONCATENATION}:
+                    annotation = set.union(*row.annotation)
+                    operator_output.append(row.output)
+                    operator_lineage.append(annotation)
+                    yield annotation
+            elif materialize_for_this_operator:
                 for row in inspection_input.row_iterator:
                     current_count += 1
 
@@ -75,28 +104,69 @@ class RowLineage(Inspection):
                         operator_lineage.append(annotation)
                     yield annotation
             else:
-                assert False
-        elif isinstance(inspection_input, InspectionInputUnaryOperator):
-            for row in inspection_input.row_iterator:
-                current_count += 1
-                annotation = row.annotation
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = set.union(*row.annotation)
+                    yield annotation
+        elif isinstance(inspection_input, InspectionInputSinkOperator):
+            if materialize_for_this_operator and self.row_count == RowLineage.ALL_ROWS:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
 
-                if current_count < self.row_count:
+                    annotation = set.union(*row.annotation)
+                    operator_lineage.append(annotation)
+                    yield annotation
+            elif materialize_for_this_operator:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+
+                    annotation = set.union(*row.annotation)
+                    if current_count < self.row_count:
+                        operator_lineage.append(annotation)
+                    yield annotation
+            else:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = set.union(*row.annotation)
+                    yield annotation
+        elif isinstance(inspection_input, InspectionInputUnaryOperator):
+            if materialize_for_this_operator and self.row_count == RowLineage.ALL_ROWS:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = row.annotation
                     operator_output.append(row.output)
                     operator_lineage.append(annotation)
-                yield annotation
+                    yield annotation
+            elif materialize_for_this_operator:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = row.annotation
+
+                    if current_count < self.row_count:
+                        operator_output.append(row.output)
+                        operator_lineage.append(annotation)
+                    yield annotation
+            else:
+                for row in inspection_input.row_iterator:
+                    current_count += 1
+                    annotation = row.annotation
+                    yield annotation
         else:
             assert False
         self._operator_count += 1
         self._op_output = operator_output
         self._op_lineage = operator_lineage
+        self._materialize_for_this_operator = materialize_for_this_operator
 
     def get_operator_annotation_after_visit(self) -> any:
-        assert self._op_lineage  # May only be called after the operator visit is finished
-        if not self._is_sink:
+        if not self._materialize_for_this_operator:
+            result = None
+        elif not self._is_sink:
+            assert self._op_lineage
             result = DataFrame(self._op_output, columns=self._output_columns)
             result["mlinspect_lineage"] = self._op_lineage
         else:
+            assert self._op_lineage
             lineage_series = Series(self._op_lineage)
             result = DataFrame(lineage_series, columns=["mlinspect_lineage"])
         self._op_output = None

--- a/test/inspections/test_lineage.py
+++ b/test/inspections/test_lineage.py
@@ -7,6 +7,7 @@ import pandas
 import numpy as np
 from pandas import DataFrame
 
+from mlinspect import OperatorType
 from mlinspect._pipeline_inspector import PipelineInspector
 from mlinspect.inspections import RowLineage
 from mlinspect.inspections._lineage import LineageId
@@ -107,3 +108,37 @@ def test_row_lineage_concat():
                                      [np.array([-0.7142857142857143, 0., 1., 0.]), {LineageId(0, 1)}]],
                                     columns=['array', 'mlinspect_lineage'])
     pandas.testing.assert_frame_equal(lineage_output.reset_index(drop=True), expected_lineage_df.reset_index(drop=True))
+
+
+def test_all_rows_for_op_type():
+    """
+    Tests whether RowLineage works for materialising all data from specific operators
+    """
+    test_code = cleandoc("""
+            import pandas as pd
+
+            df_a = pd.DataFrame({'A': [0, 2], 'B': [1, 2]})
+            df_b = pd.DataFrame({'B': [1, 2], 'C': [1, 5]})
+            df_merged = df_a.merge(df_b, on='B')
+            """)
+    row_lineage = RowLineage(RowLineage.ALL_ROWS, [OperatorType.DATA_SOURCE])
+    inspector_result = PipelineInspector \
+        .on_pipeline_from_string(test_code) \
+        .add_required_inspection(row_lineage) \
+        .execute()
+    inspection_results = list(inspector_result.dag_node_to_inspection_results.values())
+
+    lineage_output = inspection_results[0][row_lineage]
+    expected_lineage_df = DataFrame([[0, 1, {LineageId(0, 0)}],
+                                     [2, 2, {LineageId(0, 1)}]],
+                                    columns=['A', 'B', 'mlinspect_lineage'])
+    pandas.testing.assert_frame_equal(lineage_output.reset_index(drop=True), expected_lineage_df.reset_index(drop=True))
+
+    lineage_output = inspection_results[1][row_lineage]
+    expected_lineage_df = DataFrame([[1, 1, {LineageId(1, 0)}],
+                                     [2, 5, {LineageId(1, 1)}]],
+                                    columns=['B', 'C', 'mlinspect_lineage'])
+    pandas.testing.assert_frame_equal(lineage_output.reset_index(drop=True), expected_lineage_df.reset_index(drop=True))
+
+    lineage_output = inspection_results[2][row_lineage]
+    assert lineage_output is None


### PR DESCRIPTION
*Issue #, if available:* #79

*Description of changes:*
* Added a `RowLineage.ALL_ROWS` special row number option
* Added an option to restrict output materialisation to specific operators

*Example:*
* `RowLineage(RowLineage.ALL_ROWS, [OperatorType.DATA_SOURCE])`  will output all data with lineage info for data source operators


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
