### PR TITLE
ArgumentCapturing for HPs (Issue #81)

### DIFF
--- a/mlinspect/backends/_backend.py
+++ b/mlinspect/backends/_backend.py
@@ -3,6 +3,7 @@ The Interface for the different instrumentation backends
 """
 import abc
 import dataclasses
+from types import MappingProxyType
 from typing import List, Dict
 
 from mlinspect.inspections import Inspection
@@ -37,8 +38,8 @@ class Backend(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def after_call(self, operator_context, input_infos: List[AnnotatedDfObject], return_value) \
-            -> BackendResult:
+    def after_call(self, operator_context, input_infos: List[AnnotatedDfObject], return_value,
+                   non_data_function_args: Dict[str, any] = MappingProxyType({})) -> BackendResult:
         """The return value of some function"""
         # pylint: disable=too-many-arguments, unused-argument
         raise NotImplementedError

--- a/mlinspect/inspections/__init__.py
+++ b/mlinspect/inspections/__init__.py
@@ -1,6 +1,7 @@
 """
 Packages and classes we want to expose to users
 """
+from ._arg_capturing import ArgumentCapturing
 from ._completeness_of_columns import CompletenessOfColumns
 from ._count_distinct_of_columns import CountDistinctOfColumns
 from ._inspection import Inspection
@@ -25,5 +26,6 @@ __all__ = [
     'RowLineage',
     'MaterializeFirstOutputRows',
     'CompletenessOfColumns',
-    'CountDistinctOfColumns'
+    'CountDistinctOfColumns',
+    'ArgumentCapturing'
 ]

--- a/mlinspect/inspections/_arg_capturing.py
+++ b/mlinspect/inspections/_arg_capturing.py
@@ -1,0 +1,33 @@
+"""
+A simple inspection to capture important function call arguments like estimator hyperparameters
+"""
+from typing import Iterable
+
+from ._inspection import Inspection
+
+
+class ArgumentCapturing(Inspection):
+    """
+    A simple inspection to capture important function call arguments like estimator hyperparameters
+    """
+
+    def __init__(self):
+        self._captured_arguments = None
+
+    @property
+    def inspection_id(self):
+        return None
+
+    def visit_operator(self, inspection_input) -> Iterable[any]:
+        """
+        Visit an operator
+        """
+        self._captured_arguments = inspection_input.non_data_function_args
+
+        for _ in inspection_input.row_iterator:
+            yield None
+
+    def get_operator_annotation_after_visit(self) -> any:
+        captured_args = self._captured_arguments
+        self._captured_arguments = None
+        return captured_args

--- a/mlinspect/inspections/_inspection_input.py
+++ b/mlinspect/inspections/_inspection_input.py
@@ -3,7 +3,7 @@ Data classes used as input for the inspections
 """
 import dataclasses
 from enum import Enum
-from typing import Tuple, List, Iterable
+from typing import Tuple, List, Iterable, Dict
 
 
 @dataclasses.dataclass(frozen=True)
@@ -82,6 +82,7 @@ class InspectionInputDataSource:
     operator_context: OperatorContext
     output_columns: ColumnInfo
     row_iterator: Iterable[InspectionRowDataSource]
+    non_data_function_args: Dict[str, any]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -103,6 +104,7 @@ class InspectionInputUnaryOperator:
     input_columns: ColumnInfo
     output_columns: ColumnInfo
     row_iterator: Iterable[InspectionRowUnaryOperator]
+    non_data_function_args: Dict[str, any]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -124,6 +126,7 @@ class InspectionInputNAryOperator:
     inputs_columns: List[ColumnInfo]
     output_columns: ColumnInfo
     row_iterator: Iterable[InspectionRowNAryOperator]
+    non_data_function_args: Dict[str, any]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -143,3 +146,4 @@ class InspectionInputSinkOperator:
     operator_context: OperatorContext
     inputs_columns: List[ColumnInfo]
     row_iterator: Iterable[InspectionRowSinkOperator]
+    non_data_function_args: Dict[str, any]

--- a/mlinspect/monkeypatching/_monkey_patching_utils.py
+++ b/mlinspect/monkeypatching/_monkey_patching_utils.py
@@ -143,7 +143,7 @@ def get_input_info(df_object, caller_filename, lineno, function_info, optional_c
         input_info = InputInfo(input_dag_node, AnnotatedDfObject(df_object, annotation_df))
     else:
         operator_context = OperatorContext(OperatorType.DATA_SOURCE, function_info)
-        backend_result = execute_inspection_visits_data_source(operator_context, df_object)
+        backend_result = execute_inspection_visits_data_source(operator_context, df_object, {})
         if optional_code_reference:
             code_reference = "({})".format(optional_source_code)
         else:

--- a/mlinspect/monkeypatching/_patch_pandas.py
+++ b/mlinspect/monkeypatching/_patch_pandas.py
@@ -447,7 +447,7 @@ class SeriesPatching:
             result = self
             backend_result = PandasBackend.after_call(operator_context,
                                                       input_infos,
-                                                      result)
+                                                      result, {})
 
             if self.name:  # pylint: disable=no-member
                 columns = list(self.name)  # pylint: disable=no-member

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -371,24 +371,24 @@ class SklearnHasingVectorizerPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_fit_transform_active = mlinspect_fit_transform_active
 
+        self.mlinspect_non_data_func_args = {'input': input, 'encoding': encoding, 'decode_error': decode_error,
+                                             'strip_accents': strip_accents, 'lowercase': lowercase,
+                                             'preprocessor': preprocessor, 'tokenizer': tokenizer,
+                                             'stop_words': stop_words, 'token_pattern': token_pattern,
+                                             'ngram_range': ngram_range, 'analyzer': analyzer, 'n_features': n_features,
+                                             'binary': binary, 'norm': norm, 'alternate_sign': alternate_sign,
+                                             'dtype': dtype}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, input=input, encoding=encoding, decode_error=decode_error, strip_accents=strip_accents,
-                     lowercase=lowercase, preprocessor=preprocessor, tokenizer=tokenizer, stop_words=stop_words,
-                     token_pattern=token_pattern, ngram_range=ngram_range, analyzer=analyzer, n_features=n_features,
-                     binary=binary, norm=norm, alternate_sign=alternate_sign, dtype=dtype)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
             self.mlinspect_optional_code_reference = optional_code_reference
             self.mlinspect_optional_source_code = optional_source_code
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, input=input, encoding=encoding,
-                                             decode_error=decode_error, strip_accents=strip_accents,
-                                             lowercase=lowercase, preprocessor=preprocessor, tokenizer=tokenizer,
-                                             stop_words=stop_words, token_pattern=token_pattern,
-                                             ngram_range=ngram_range, analyzer=analyzer, n_features=n_features,
-                                             binary=binary, norm=norm, alternate_sign=alternate_sign, dtype=dtype)
+        return execute_patched_func_no_op_id(original, execute_inspections, self, **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit_transform')
     @gorilla.settings(allow_hit=True)
@@ -406,7 +406,8 @@ class SklearnHasingVectorizerPatching:
         result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
         backend_result = SklearnBackend.after_call(operator_context,
                                                    input_infos,
-                                                   result)
+                                                   result,
+                                                   self.mlinspect_non_data_func_args)
         new_return_value = backend_result.annotated_dfobject.result_data
         dag_node = DagNode(singleton.get_next_op_id(),
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -434,7 +435,8 @@ class SklearnHasingVectorizerPatching:
             result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
             backend_result = SklearnBackend.after_call(operator_context,
                                                        input_infos,
-                                                       result)
+                                                       result,
+                                                       self.mlinspect_non_data_func_args)
             new_return_value = backend_result.annotated_dfobject.result_data
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -1245,6 +1245,8 @@ class SklearnKerasClassifierPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
+        self.mlinspect_non_data_func_args = sk_params
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
             original(self, build_fn=build_fn, **sk_params)
@@ -1274,7 +1276,8 @@ class SklearnKerasClassifierPatching:
         original(self, train_data_result, train_labels_result, *args[2:], **kwargs)
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
-                                                             None)
+                                                             None,
+                                                             self.mlinspect_non_data_func_args)
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -1322,7 +1325,8 @@ class SklearnKerasClassifierPatching:
 
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
-                                                                 predictions)
+                                                                 predictions,
+                                                                 self.mlinspect_non_data_func_args)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -472,17 +472,18 @@ class SklearnKBinsDiscretizerPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_fit_transform_active = mlinspect_fit_transform_active
 
+        self.mlinspect_non_data_func_args = {'n_bins': n_bins, 'encode': encode, 'strategy': strategy}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, n_bins=n_bins, encode=encode, strategy=strategy)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
             self.mlinspect_optional_code_reference = optional_code_reference
             self.mlinspect_optional_source_code = optional_source_code
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, n_bins=n_bins, encode=encode,
-                                             strategy=strategy)
+        return execute_patched_func_no_op_id(original, execute_inspections, self, **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit_transform')
     @gorilla.settings(allow_hit=True)
@@ -500,7 +501,8 @@ class SklearnKBinsDiscretizerPatching:
         result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
         backend_result = SklearnBackend.after_call(operator_context,
                                                    input_infos,
-                                                   result)
+                                                   result,
+                                                   self.mlinspect_non_data_func_args)
         new_return_value = backend_result.annotated_dfobject.result_data
         assert isinstance(new_return_value, MlinspectNdarray)
         dag_node = DagNode(singleton.get_next_op_id(),
@@ -529,7 +531,8 @@ class SklearnKBinsDiscretizerPatching:
             result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
             backend_result = SklearnBackend.after_call(operator_context,
                                                        input_infos,
-                                                       result)
+                                                       result,
+                                                       self.mlinspect_non_data_func_args)
             new_return_value = backend_result.annotated_dfobject.result_data
             assert isinstance(new_return_value, MlinspectNdarray)
             dag_node = DagNode(singleton.get_next_op_id(),
@@ -567,17 +570,19 @@ class SklearnOneHotEncoderPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_fit_transform_active = mlinspect_fit_transform_active
 
+        self.mlinspect_non_data_func_args = {'categories': categories, 'drop': drop, 'sparse': sparse, 'dtype': dtype,
+                                             'handle_unknown': handle_unknown}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, categories=categories, drop=drop, sparse=sparse, dtype=dtype, handle_unknown=handle_unknown)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
             self.mlinspect_optional_code_reference = optional_code_reference
             self.mlinspect_optional_source_code = optional_source_code
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, categories=categories, drop=drop,
-                                             sparse=sparse, dtype=dtype, handle_unknown=handle_unknown)
+        return execute_patched_func_no_op_id(original, execute_inspections, self, **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit_transform')
     @gorilla.settings(allow_hit=True)
@@ -595,7 +600,8 @@ class SklearnOneHotEncoderPatching:
         result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
         backend_result = SklearnBackend.after_call(operator_context,
                                                    input_infos,
-                                                   result)
+                                                   result,
+                                                   self.mlinspect_non_data_func_args)
         new_return_value = backend_result.annotated_dfobject.result_data
         dag_node = DagNode(singleton.get_next_op_id(),
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -623,7 +629,8 @@ class SklearnOneHotEncoderPatching:
             result = original(self, input_infos[0].result_data, *args[1:], **kwargs)
             backend_result = SklearnBackend.after_call(operator_context,
                                                        input_infos,
-                                                       result)
+                                                       result,
+                                                       self.mlinspect_non_data_func_args)
             new_return_value = backend_result.annotated_dfobject.result_data
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -865,14 +865,21 @@ class SklearnDecisionTreePatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
+        self.mlinspect_non_data_function_arguments = {'criterion': criterion, 'splitter': splitter,
+                                                      'max_depth': max_depth,
+                                                      'min_samples_split': min_samples_split,
+                                                      'min_samples_leaf': min_samples_leaf,
+                                                      'min_weight_fraction_leaf': min_weight_fraction_leaf,
+                                                      'max_features': max_features,
+                                                      'random_state': random_state, 'max_leaf_nodes': max_leaf_nodes,
+                                                      'min_impurity_decrease': min_impurity_decrease,
+                                                      'min_impurity_split': min_impurity_split,
+                                                      'class_weight': class_weight, 'presort': presort,
+                                                      'ccp_alpha': ccp_alpha}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, criterion=criterion, splitter=splitter, max_depth=max_depth,
-                     min_samples_split=min_samples_split, min_samples_leaf=min_samples_leaf,
-                     min_weight_fraction_leaf=min_weight_fraction_leaf, max_features=max_features,
-                     random_state=random_state, max_leaf_nodes=max_leaf_nodes,
-                     min_impurity_decrease=min_impurity_decrease, min_impurity_split=min_impurity_split,
-                     class_weight=class_weight, presort=presort, ccp_alpha=ccp_alpha)
+            original(self, **self.mlinspect_non_data_function_arguments)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
@@ -880,15 +887,8 @@ class SklearnDecisionTreePatching:
             self.mlinspect_optional_source_code = optional_source_code
             self.mlinspect_estimator_node_id = None
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, criterion=criterion,
-                                             splitter=splitter, max_depth=max_depth,
-                                             min_samples_split=min_samples_split, min_samples_leaf=min_samples_leaf,
-                                             min_weight_fraction_leaf=min_weight_fraction_leaf,
-                                             max_features=max_features,
-                                             random_state=random_state, max_leaf_nodes=max_leaf_nodes,
-                                             min_impurity_decrease=min_impurity_decrease,
-                                             min_impurity_split=min_impurity_split,
-                                             class_weight=class_weight, presort=presort, ccp_alpha=ccp_alpha)
+        return execute_patched_func_no_op_id(original, execute_inspections, self,
+                                             **self.mlinspect_non_data_function_arguments)
 
     @gorilla.name('fit')
     @gorilla.settings(allow_hit=True)
@@ -909,7 +909,8 @@ class SklearnDecisionTreePatching:
         original(self, train_data_result, train_labels_result, *args[2:], **kwargs)
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
-                                                             None)
+                                                             None,
+                                                             self.mlinspect_non_data_function_arguments)
 
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
@@ -925,6 +926,7 @@ class SklearnDecisionTreePatching:
     @gorilla.settings(allow_hit=True)
     def patched_score(self, *args, **kwargs):
         """ Patch for ('sklearn.tree._classes.DecisionTreeClassifier', 'score') """
+
         # pylint: disable=no-method-argument
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
@@ -953,7 +955,8 @@ class SklearnDecisionTreePatching:
 
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
-                                                                 predictions)
+                                                                 predictions,
+                                                                 self.mlinspect_non_data_function_arguments)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),
@@ -993,14 +996,21 @@ class SklearnSGDClassifierPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
+        self.mlinspect_non_data_function_arguments = {'loss': loss, 'penalty': penalty, 'alpha': alpha,
+                                                      'l1_ratio': l1_ratio, 'fit_intercept': fit_intercept,
+                                                      'max_iter': max_iter, 'tol': tol, 'shuffle': shuffle,
+                                                      'verbose': verbose, 'epsilon': epsilon, 'n_jobs': n_jobs,
+                                                      'random_state': random_state, 'learning_rate': learning_rate,
+                                                      'eta0': eta0, 'power_t': power_t,
+                                                      'early_stopping': early_stopping,
+                                                      'validation_fraction': validation_fraction,
+                                                      'n_iter_no_change': n_iter_no_change,
+                                                      'class_weight': class_weight, 'warm_start': warm_start,
+                                                      'average': average}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, loss=loss, penalty=penalty, alpha=alpha, l1_ratio=l1_ratio, fit_intercept=fit_intercept,
-                     max_iter=max_iter, tol=tol, shuffle=shuffle, verbose=verbose, epsilon=epsilon, n_jobs=n_jobs,
-                     random_state=random_state, learning_rate=learning_rate, eta0=eta0, power_t=power_t,
-                     early_stopping=early_stopping, validation_fraction=validation_fraction,
-                     n_iter_no_change=n_iter_no_change, class_weight=class_weight, warm_start=warm_start,
-                     average=average)
+            original(self, **self.mlinspect_non_data_function_arguments)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
@@ -1008,15 +1018,8 @@ class SklearnSGDClassifierPatching:
             self.mlinspect_optional_source_code = optional_source_code
             self.mlinspect_estimator_node_id = None
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, loss=loss, penalty=penalty,
-                                             alpha=alpha, l1_ratio=l1_ratio, fit_intercept=fit_intercept,
-                                             max_iter=max_iter, tol=tol, shuffle=shuffle, verbose=verbose,
-                                             epsilon=epsilon, n_jobs=n_jobs, random_state=random_state,
-                                             learning_rate=learning_rate, eta0=eta0, power_t=power_t,
-                                             early_stopping=early_stopping, validation_fraction=validation_fraction,
-                                             n_iter_no_change=n_iter_no_change, class_weight=class_weight,
-                                             warm_start=warm_start,
-                                             average=average)
+        return execute_patched_func_no_op_id(original, execute_inspections, self,
+                                             **self.mlinspect_non_data_function_arguments)
 
     @gorilla.name('fit')
     @gorilla.settings(allow_hit=True)
@@ -1036,7 +1039,8 @@ class SklearnSGDClassifierPatching:
         original(self, train_data_result, train_labels_result, *args[2:], **kwargs)
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
-                                                             None)
+                                                             None,
+                                                             self.mlinspect_non_data_function_arguments)
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -1051,6 +1055,7 @@ class SklearnSGDClassifierPatching:
     @gorilla.settings(allow_hit=True)
     def patched_score(self, *args, **kwargs):
         """ Patch for ('sklearn.linear_model._stochastic_gradient.SGDClassifier', 'score') """
+
         # pylint: disable=no-method-argument
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
@@ -1083,7 +1088,8 @@ class SklearnSGDClassifierPatching:
 
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
-                                                                 predictions)
+                                                                 predictions,
+                                                                 self.mlinspect_non_data_function_arguments)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),
@@ -1101,6 +1107,7 @@ class SklearnSGDClassifierPatching:
 @gorilla.patches(linear_model.LogisticRegression)
 class SklearnLogisticRegressionPatching:
     """ Patches for sklearn LogisticRegression"""
+
     # pylint: disable=too-few-public-methods
 
     @gorilla.name('__init__')
@@ -1177,6 +1184,7 @@ class SklearnLogisticRegressionPatching:
     @gorilla.settings(allow_hit=True)
     def patched_score(self, *args, **kwargs):
         """ Patch for ('sklearn.linear_model._logistic.LogisticRegression', 'score') """
+
         # pylint: disable=no-method-argument
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -1125,26 +1125,23 @@ class SklearnLogisticRegressionPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
+        self.mlinspect_non_data_func_args = {'penalty': penalty, 'dual': dual, 'tol': tol, 'C': C,
+                                             'fit_intercept': fit_intercept, 'intercept_scaling': intercept_scaling,
+                                             'class_weight': class_weight, 'random_state': random_state,
+                                             'solver': solver, 'max_iter': max_iter, 'multi_class': multi_class,
+                                             'verbose': verbose, 'warm_start': warm_start, 'n_jobs': n_jobs,
+                                             'l1_ratio': l1_ratio}
+
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, penalty=penalty, dual=dual, tol=tol, C=C,
-                     fit_intercept=fit_intercept, intercept_scaling=intercept_scaling, class_weight=class_weight,
-                     random_state=random_state, solver=solver, max_iter=max_iter,
-                     multi_class=multi_class, verbose=verbose, warm_start=warm_start, n_jobs=n_jobs,
-                     l1_ratio=l1_ratio)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
             self.mlinspect_optional_code_reference = optional_code_reference
             self.mlinspect_optional_source_code = optional_source_code
 
-        return execute_patched_func_no_op_id(original, execute_inspections, self, penalty=penalty, dual=dual, tol=tol,
-                                             C=C, fit_intercept=fit_intercept, intercept_scaling=intercept_scaling,
-                                             class_weight=class_weight,
-                                             random_state=random_state, solver=solver, max_iter=max_iter,
-                                             multi_class=multi_class, verbose=verbose, warm_start=warm_start,
-                                             n_jobs=n_jobs,
-                                             l1_ratio=l1_ratio)
+        return execute_patched_func_no_op_id(original, execute_inspections, self, **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit')
     @gorilla.settings(allow_hit=True)
@@ -1165,7 +1162,8 @@ class SklearnLogisticRegressionPatching:
         original(self, train_data_result, train_labels_result, *args[2:], **kwargs)
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
-                                                             None)
+                                                             None,
+                                                             self.mlinspect_non_data_func_args)
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -1213,7 +1211,8 @@ class SklearnLogisticRegressionPatching:
 
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
-                                                                 predictions)
+                                                                 predictions,
+                                                                 self.mlinspect_non_data_func_args)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),

--- a/mlinspect/monkeypatching/_patch_sklearn.py
+++ b/mlinspect/monkeypatching/_patch_sklearn.py
@@ -865,21 +865,19 @@ class SklearnDecisionTreePatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
-        self.mlinspect_non_data_function_arguments = {'criterion': criterion, 'splitter': splitter,
-                                                      'max_depth': max_depth,
-                                                      'min_samples_split': min_samples_split,
-                                                      'min_samples_leaf': min_samples_leaf,
-                                                      'min_weight_fraction_leaf': min_weight_fraction_leaf,
-                                                      'max_features': max_features,
-                                                      'random_state': random_state, 'max_leaf_nodes': max_leaf_nodes,
-                                                      'min_impurity_decrease': min_impurity_decrease,
-                                                      'min_impurity_split': min_impurity_split,
-                                                      'class_weight': class_weight, 'presort': presort,
-                                                      'ccp_alpha': ccp_alpha}
+        self.mlinspect_non_data_func_args = {'criterion': criterion, 'splitter': splitter, 'max_depth': max_depth,
+                                             'min_samples_split': min_samples_split,
+                                             'min_samples_leaf': min_samples_leaf,
+                                             'min_weight_fraction_leaf': min_weight_fraction_leaf,
+                                             'max_features': max_features, 'random_state': random_state,
+                                             'max_leaf_nodes': max_leaf_nodes,
+                                             'min_impurity_decrease': min_impurity_decrease,
+                                             'min_impurity_split': min_impurity_split, 'class_weight': class_weight,
+                                             'presort': presort, 'ccp_alpha': ccp_alpha}
 
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, **self.mlinspect_non_data_function_arguments)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
@@ -888,7 +886,7 @@ class SklearnDecisionTreePatching:
             self.mlinspect_estimator_node_id = None
 
         return execute_patched_func_no_op_id(original, execute_inspections, self,
-                                             **self.mlinspect_non_data_function_arguments)
+                                             **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit')
     @gorilla.settings(allow_hit=True)
@@ -910,7 +908,7 @@ class SklearnDecisionTreePatching:
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
                                                              None,
-                                                             self.mlinspect_non_data_function_arguments)
+                                                             self.mlinspect_non_data_func_args)
 
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
@@ -956,7 +954,7 @@ class SklearnDecisionTreePatching:
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
                                                                  predictions,
-                                                                 self.mlinspect_non_data_function_arguments)
+                                                                 self.mlinspect_non_data_func_args)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),
@@ -996,21 +994,19 @@ class SklearnSGDClassifierPatching:
         self.mlinspect_optional_source_code = mlinspect_optional_source_code
         self.mlinspect_estimator_node_id = mlinspect_estimator_node_id
 
-        self.mlinspect_non_data_function_arguments = {'loss': loss, 'penalty': penalty, 'alpha': alpha,
-                                                      'l1_ratio': l1_ratio, 'fit_intercept': fit_intercept,
-                                                      'max_iter': max_iter, 'tol': tol, 'shuffle': shuffle,
-                                                      'verbose': verbose, 'epsilon': epsilon, 'n_jobs': n_jobs,
-                                                      'random_state': random_state, 'learning_rate': learning_rate,
-                                                      'eta0': eta0, 'power_t': power_t,
-                                                      'early_stopping': early_stopping,
-                                                      'validation_fraction': validation_fraction,
-                                                      'n_iter_no_change': n_iter_no_change,
-                                                      'class_weight': class_weight, 'warm_start': warm_start,
-                                                      'average': average}
+        self.mlinspect_non_data_func_args = {'loss': loss, 'penalty': penalty, 'alpha': alpha, 'l1_ratio': l1_ratio,
+                                             'fit_intercept': fit_intercept, 'max_iter': max_iter, 'tol': tol,
+                                             'shuffle': shuffle, 'verbose': verbose, 'epsilon': epsilon,
+                                             'n_jobs': n_jobs, 'random_state': random_state,
+                                             'learning_rate': learning_rate, 'eta0': eta0, 'power_t': power_t,
+                                             'early_stopping': early_stopping,
+                                             'validation_fraction': validation_fraction,
+                                             'n_iter_no_change': n_iter_no_change,
+                                             'class_weight': class_weight, 'warm_start': warm_start, 'average': average}
 
         def execute_inspections(_, caller_filename, lineno, optional_code_reference, optional_source_code):
             """ Execute inspections, add DAG node """
-            original(self, **self.mlinspect_non_data_function_arguments)
+            original(self, **self.mlinspect_non_data_func_args)
 
             self.mlinspect_caller_filename = caller_filename
             self.mlinspect_lineno = lineno
@@ -1019,7 +1015,7 @@ class SklearnSGDClassifierPatching:
             self.mlinspect_estimator_node_id = None
 
         return execute_patched_func_no_op_id(original, execute_inspections, self,
-                                             **self.mlinspect_non_data_function_arguments)
+                                             **self.mlinspect_non_data_func_args)
 
     @gorilla.name('fit')
     @gorilla.settings(allow_hit=True)
@@ -1040,7 +1036,7 @@ class SklearnSGDClassifierPatching:
         estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                              input_infos,
                                                              None,
-                                                             self.mlinspect_non_data_function_arguments)
+                                                             self.mlinspect_non_data_func_args)
         self.mlinspect_estimator_node_id = singleton.get_next_op_id()  # pylint: disable=attribute-defined-outside-init
         dag_node = DagNode(self.mlinspect_estimator_node_id,
                            BasicCodeLocation(self.mlinspect_caller_filename, self.mlinspect_lineno),
@@ -1089,7 +1085,7 @@ class SklearnSGDClassifierPatching:
             estimator_backend_result = SklearnBackend.after_call(operator_context,
                                                                  input_infos,
                                                                  predictions,
-                                                                 self.mlinspect_non_data_function_arguments)
+                                                                 self.mlinspect_non_data_func_args)
 
             dag_node = DagNode(singleton.get_next_op_id(),
                                BasicCodeLocation(caller_filename, lineno),

--- a/test/example_pipelines/test_patch_healthcare_utils.py
+++ b/test/example_pipelines/test_patch_healthcare_utils.py
@@ -10,6 +10,7 @@ from pandas import DataFrame
 from testfixtures import compare
 
 from mlinspect import OperatorContext, FunctionInfo, OperatorType
+from mlinspect.inspections import ArgumentCapturing
 from mlinspect.instrumentation import _pipeline_executor
 from mlinspect.instrumentation._dag_node import DagNode, CodeReference, BasicCodeLocation, DagNodeDetails, \
     OptionalCodeInfo
@@ -89,3 +90,59 @@ def test_my_word_to_vec_transformer():
                                     columns=['array', 'mlinspect_lineage'])
     pandas.testing.assert_series_equal(lineage_output["mlinspect_lineage"], expected_lineage_df["mlinspect_lineage"])
     assert expected_lineage_df.iloc[0, 0].shape == (3,)
+
+
+def test_arg_capturing_my_word_to_vec_transformer():
+    """
+    Tests whether ArgumentCapturing works for MyW2VTransformer
+    """
+    test_code = cleandoc("""
+                    import pandas as pd
+                    from example_pipelines.healthcare.healthcare_utils import MyW2VTransformer
+                    import numpy as np
+    
+                    df = pd.DataFrame({'A': ['cat_a', 'cat_b', 'cat_a', 'cat_c']})
+                    word_to_vec = MyW2VTransformer(min_count=2, size=2, workers=1)
+                    encoded_data = word_to_vec.fit_transform(df)
+                    assert encoded_data.shape == (4, 2)
+                    test_df = pd.DataFrame({'A': ['cat_a', 'cat_b', 'cat_a', 'cat_c']})
+                    encoded_data = word_to_vec.transform(test_df)
+                    """)
+
+    inspector_result = _pipeline_executor.singleton.run(python_code=test_code, track_code_references=True,
+                                                        inspections=[ArgumentCapturing()],
+                                                        custom_monkey_patching=[custom_monkeypatching])
+    fit_transform_node = list(inspector_result.dag.nodes)[1]
+    transform_node = list(inspector_result.dag.nodes)[3]
+
+    expected_fit_transform = DagNode(1,
+                                     BasicCodeLocation("<string-source>", 6),
+                                     OperatorContext(OperatorType.TRANSFORMER,
+                                                     FunctionInfo('example_pipelines.healthcare.healthcare_utils',
+                                                                  'MyW2VTransformer')),
+                                     DagNodeDetails('Word2Vec: fit_transform', ['array']),
+                                     OptionalCodeInfo(CodeReference(6, 14, 6, 62),
+                                                      'MyW2VTransformer(min_count=2, size=2, workers=1)'))
+    expected_transform = DagNode(3,
+                                 BasicCodeLocation("<string-source>", 6),
+                                 OperatorContext(OperatorType.TRANSFORMER,
+                                                 FunctionInfo('example_pipelines.healthcare.healthcare_utils',
+                                                              'MyW2VTransformer')),
+                                 DagNodeDetails('Word2Vec: transform', ['array']),
+                                 OptionalCodeInfo(CodeReference(6, 14, 6, 62),
+                                                  'MyW2VTransformer(min_count=2, size=2, workers=1)'))
+
+    compare(fit_transform_node, expected_fit_transform)
+    compare(transform_node, expected_transform)
+
+    expected_args = {'size': 2, 'alpha': 0.025, 'window': 5, 'min_count': 2, 'max_vocab_size': None, 'sample': 0.001,
+                     'seed': 1, 'workers': 1, 'min_alpha': 0.0001, 'sg': 0, 'hs': 0, 'negative': 5, 'cbow_mean': 1,
+                     'iter': 5, 'null_word': 0, 'trim_rule': None, 'sorted_vocab': 1, 'batch_words': 10000}
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[expected_fit_transform]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[expected_transform]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)

--- a/test/inspections/test_arg_capturing.py
+++ b/test/inspections/test_arg_capturing.py
@@ -1,0 +1,136 @@
+"""
+Tests whether ArgumentCapturing works
+"""
+from inspect import cleandoc
+
+from testfixtures import compare
+
+from mlinspect import OperatorType, DagNode, BasicCodeLocation, OperatorContext, FunctionInfo, DagNodeDetails, \
+    OptionalCodeInfo, CodeReference
+from mlinspect.inspections import ArgumentCapturing
+from mlinspect.instrumentation import _pipeline_executor
+
+
+def test_arg_capturing_sklearn_decision_tree():
+    """
+    Tests whether ArgumentCapturing works for the sklearn DecisionTreeClassifier
+    """
+    test_code = cleandoc("""
+                    import pandas as pd
+                    from sklearn.preprocessing import label_binarize, StandardScaler
+                    from sklearn.tree import DecisionTreeClassifier
+                    import numpy as np
+
+                    df = pd.DataFrame({'A': [0, 1, 2, 3], 'B': [0, 1, 2, 3], 'target': ['no', 'no', 'yes', 'yes']})
+
+                    train = StandardScaler().fit_transform(df[['A', 'B']])
+                    target = label_binarize(df['target'], classes=['no', 'yes'])
+
+                    clf = DecisionTreeClassifier()
+                    clf = clf.fit(train, target)
+
+                    test_df = pd.DataFrame({'A': [0., 0.6], 'B':  [0., 0.6], 'target': ['no', 'yes']})
+                    test_labels = label_binarize(test_df['target'], classes=['no', 'yes'])
+                    test_score = clf.score(test_df[['A', 'B']], test_labels)
+                    assert test_score == 1.0
+                    """)
+
+    inspector_result = _pipeline_executor.singleton.run(python_code=test_code, track_code_references=True,
+                                                        inspections=[ArgumentCapturing()])
+    classifier_node = list(inspector_result.dag.nodes)[7]
+    score_node = list(inspector_result.dag.nodes)[14]
+
+    expected_classifier = DagNode(7,
+                                  BasicCodeLocation("<string-source>", 11),
+                                  OperatorContext(OperatorType.ESTIMATOR,
+                                                  FunctionInfo('sklearn.tree._classes', 'DecisionTreeClassifier')),
+                                  DagNodeDetails('Decision Tree', []),
+                                  OptionalCodeInfo(CodeReference(11, 6, 11, 30),
+                                                   'DecisionTreeClassifier()'))
+    expected_score = DagNode(14,
+                             BasicCodeLocation("<string-source>", 16),
+                             OperatorContext(OperatorType.SCORE,
+                                             FunctionInfo('sklearn.tree._classes.DecisionTreeClassifier', 'score')),
+                             DagNodeDetails('Decision Tree', []),
+                             OptionalCodeInfo(CodeReference(16, 13, 16, 56),
+                                              "clf.score(test_df[['A', 'B']], test_labels)"))
+
+    compare(classifier_node, expected_classifier)
+    compare(score_node, expected_score)
+
+    expected_args = {'criterion': 'gini', 'splitter': 'best', 'max_depth': None, 'min_samples_split': 2,
+                     'min_samples_leaf': 1, 'min_weight_fraction_leaf': 0.0, 'max_features': None, 'random_state': None,
+                     'max_leaf_nodes': None, 'min_impurity_decrease': 0.0, 'min_impurity_split': None,
+                     'class_weight': None, 'presort': 'deprecated', 'ccp_alpha': 0.0}
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[classifier_node]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[score_node]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)
+
+
+def test_arg_capturing_sklearn_sgd_classifier():
+    """
+    Tests whether ArgumentCapturing works for the sklearn SGDClassifier
+    """
+    test_code = cleandoc("""
+                import pandas as pd
+                from sklearn.preprocessing import label_binarize, StandardScaler
+                from sklearn.linear_model import SGDClassifier
+                import numpy as np
+
+                df = pd.DataFrame({'A': [0, 1, 2, 3], 'B': [0, 1, 2, 3], 'target': ['no', 'no', 'yes', 'yes']})
+
+                train = StandardScaler().fit_transform(df[['A', 'B']])
+                target = label_binarize(df['target'], classes=['no', 'yes'])
+
+                clf = SGDClassifier(loss='log', random_state=42)
+                clf = clf.fit(train, target)
+
+                test_df = pd.DataFrame({'A': [0., 0.6], 'B':  [0., 0.6], 'target': ['no', 'yes']})
+                test_labels = label_binarize(test_df['target'], classes=['no', 'yes'])
+                test_score = clf.score(test_df[['A', 'B']], test_labels)
+                assert test_score == 1.0
+                    """)
+
+    inspector_result = _pipeline_executor.singleton.run(python_code=test_code, track_code_references=True,
+                                                        inspections=[ArgumentCapturing()])
+    classifier_node = list(inspector_result.dag.nodes)[7]
+    score_node = list(inspector_result.dag.nodes)[14]
+
+    expected_classifier = DagNode(7,
+                                  BasicCodeLocation("<string-source>", 11),
+                                  OperatorContext(OperatorType.ESTIMATOR,
+                                                  FunctionInfo('sklearn.linear_model._stochastic_gradient',
+                                                               'SGDClassifier')),
+                                  DagNodeDetails('SGD Classifier', []),
+                                  OptionalCodeInfo(CodeReference(11, 6, 11, 48),
+                                                   "SGDClassifier(loss='log', random_state=42)"))
+    expected_score = DagNode(14,
+                             BasicCodeLocation("<string-source>", 16),
+                             OperatorContext(OperatorType.SCORE,
+                                             FunctionInfo('sklearn.linear_model._stochastic_gradient.SGDClassifier',
+                                                          'score')),
+                             DagNodeDetails('SGD Classifier', []),
+                             OptionalCodeInfo(CodeReference(16, 13, 16, 56),
+                                              "clf.score(test_df[['A', 'B']], test_labels)"))
+
+    compare(classifier_node, expected_classifier)
+    compare(score_node, expected_score)
+
+    expected_args = {'loss': 'log', 'penalty': 'l2', 'alpha': 0.0001, 'l1_ratio': 0.15, 'fit_intercept': True,
+                     'max_iter': 1000, 'tol': 0.001, 'shuffle': True, 'verbose': 0, 'epsilon': 0.1, 'n_jobs': None,
+                     'random_state': 42, 'learning_rate': 'optimal', 'eta0': 0.0, 'power_t': 0.5,
+                     'early_stopping': False, 'validation_fraction': 0.1, 'n_iter_no_change': 5, 'class_weight': None,
+                     'warm_start': False, 'average': False}
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[classifier_node]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)
+
+    inspection_results_tree = inspector_result.dag_node_to_inspection_results[score_node]
+    captured_args = inspection_results_tree[ArgumentCapturing()]
+    compare(captured_args, expected_args)

--- a/test/inspections/test_arg_capturing.py
+++ b/test/inspections/test_arg_capturing.py
@@ -484,7 +484,7 @@ def test_arg_capturing_simple_imputer():
 
 def test_arg_capturing_function_transformer():
     """
-    Tests whether ArgumentCapturing works for the sklearn SimpleImputer
+    Tests whether ArgumentCapturing works for the sklearn FunctionTransformer
     """
     test_code = cleandoc("""
                     import pandas as pd

--- a/test/monkeypatching/test_patch_sklearn.py
+++ b/test/monkeypatching/test_patch_sklearn.py
@@ -320,7 +320,8 @@ def test_kbins_discretizer():
                                                                     'KBinsDiscretizer')),
                                        DagNodeDetails('K-Bins Discretizer: transform', ['array']),
                                        OptionalCodeInfo(CodeReference(6, 14, 6, 78),
-                                                        "KBinsDiscretizer(n_bins=3, encode='ordinal', strategy='uniform')"))
+                                                        "KBinsDiscretizer(n_bins=3, encode='ordinal', "
+                                                        "strategy='uniform')"))
     expected_dag.add_edge(expected_data_source_two, expected_transformer_two)
     compare(networkx.to_dict_of_dicts(inspector_result.dag), networkx.to_dict_of_dicts(expected_dag))
 


### PR DESCRIPTION
*Issue #, if available:* #81

*Description of changes:*
* Implemented a mechanism to expose function arguments from instrumented functions to inspections.
* Exposed function arguments from transformers and estimators to inspections. 
* The most important use case is capturing of hyperparameters from estimators and transformers.
* Using this interface, we do not want to expose the actual data, which we expose in a special format already, but only non-data arguments.
* In the future, we can also use the same mechanism for other operator types, too, if we want to use their arguments for something. I only didn't add that yet because of time constraints, we have to go through all args and kwargs of instrumented functions and decide whether we want to expose them (we do not want to expose actual data this way, only hyperparameters).
* Added an `ArgumentCapturing` inspection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
