### PR TITLE
Set env variable in CI workflow to address numpy issue #22623

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements.txt') }}-${{ hashFiles('requirements/requirements.dev.txt') }}
 
       - name: Install dependencies
+        env:
+          SETUPTOOLS_USE_DISTUTILS: stdlib
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager ".[dev]"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prerequisite: Python 3.9
 	
 4. Install pip dependencies 
 
-    `pip install -e .[dev]` <br>
+    `SETUPTOOLS_USE_DISTUTILS=stdlib pip install -e .[dev]` <br>
 
 5. To ensure everything works, you can run the tests (without graphviz, the visualisation test will fail)
 


### PR DESCRIPTION
*Issue #, if available:*

Around 10 days ago, the CI workflows started failing (starting with https://github.com/stefan-grafberger/mlinspect/actions/runs/3513290506) on the step of dependency installation. We tracked it to an apparent bug introduced recently in numpy (https://github.com/numpy/numpy/issues/22623).

*Description of changes:*

I tried various fixes proposed in the comments, but apparently pinning the version of `setuptools` does not always work. The fix from this comment finally worked: https://github.com/numpy/numpy/issues/22623#issuecomment-1321725976.

See https://github.com/stefan-grafberger/mlinspect/actions/runs/3522628039 for first successful build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
